### PR TITLE
[doc] Add Initial Code Owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,19 @@
+# This file specifies default reviewers for new pull requests. This is used as a
+# convenience - the manticore project doesn't currently have a formalised notion
+# of "code owners".
+#
+# Note: The default reviewers aren't required to give a review prior to merging.
+# You are encouraged to add non-default reviewers where you know someone else
+# may have useful insight or has been recently working in the area touched by
+# your PR. Anyone is able to contribute to pull request review, and is
+# encouraged to do so.
+
+# Order: last matching pattern takes the most precedence.
+#   Please refer the link for the detail
+#   https://help.github.com/en/articles/about-code-owners
+
+# License related files
+LICENSE*            @asb
+CLA*                @asb
+
+*                   @mcy @lenary @gkelly @moidx


### PR DESCRIPTION
As discussed on Slack. This is only so we tag the right people so they see new PRs, rather than requiring sign-off from all "owners" for every PR, following the same rules as we have for OpenTitan.