### PR TITLE
[cargo] Add a temporary project to hold `mantiocore` on crates.io

### DIFF
--- a/.crates-io-staging/Cargo.toml
+++ b/.crates-io-staging/Cargo.toml
@@ -1,0 +1,17 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+[package]
+name = "manticore"
+version = "0.0.0"
+edition = "2018"
+
+authors = ["lowRISC Contributors"]
+license = "Apache-2.0"
+homepage = "https://opentitan.org/"
+repository = "https://github.com/lowRISC/manticore"
+description = "A WIP implementation of the Cerberus attestation protocol"
+
+readme = "README.md.crates-io"
+include = ["Cargo.toml", "src/lib.rs", "README.md.cargo-io"]

--- a/.crates-io-staging/README.md
+++ b/.crates-io-staging/README.md
@@ -1,0 +1,5 @@
+# What is this directory?
+
+This directory is a temporary staging area for holding the name `manticore` on
+crates.io. Because crates.io is exclusively first-come-first-serve, it is
+necessary to squat the name until we have code suitable for release.

--- a/.crates-io-staging/README.md.crates-io
+++ b/.crates-io-staging/README.md.crates-io
@@ -1,0 +1,22 @@
+# Manticore
+
+## About the project
+
+Manticore is a work-in-progress implementation of the Open Compute Project's
+[Cerberus] attestation protocol, developed as part of the [OpenTitan project].
+
+Manticore aims to eventually achieve parity with Microsoft's C implementation,
+while also being a proving ground for improvements and enhancements of the
+protocol.
+
+[Cerberus]: https://github.com/opencomputeproject/Project_Olympus/tree/master/Project_Cerberus
+[OpenTitan project]: https://opentitan.org
+
+## Using `manticore`
+
+Manticore's API is still unstable, and not at the point where it can be safely
+released onto `crates.io`. For now, use a git dependency instead:
+```
+manticore = { git = "https://git@github.com:lowRISC/manticore.git" }
+```
+We reserve the right to break any code that depends on the bleeding edge.

--- a/.crates-io-staging/src/lib.rs
+++ b/.crates-io-staging/src/lib.rs
@@ -1,0 +1,1 @@
+//! Nothing yet.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,9 +5,13 @@
 [package]
 name = "manticore"
 version = "0.1.0"
+edition = "2018"
+
 authors = ["lowRISC Contributors"]
 license = "Apache-2.0"
-edition = "2018"
+homepage = "https://opentitan.org/"
+repository = "https://github.com/lowRISC/manticore"
+description = "A WIP implementation of the Cerberus attestation protocol"
 
 [dependencies]
 arrayvec = "0.5.1"


### PR DESCRIPTION
crates.io has a first-come-first-serve name policy, and a no-deletions policy (in other words, they will *not* honor our use of the name if someone scoops us). Thus, while Manticore is not suitable to publish yet, we do need to hold onto the name for now.