### PR TITLE
[ring] Make crypto::ring part of Manticore's API

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -27,10 +27,12 @@ jobs:
 
     - name: Build with default settings
       run: cargo build --verbose
-    - name: Build with features
+    - name: Build with no features
+      run: cargo build --verbose --no-default-features
+    - name: Build with all features
       run: cargo build --verbose --all-features
     - name: Build for baremetal RISC-V
-      run: cargo build --verbose --target riscv32imc-unknown-none-elf
+      run: cargo build --verbose --no-default-features --target riscv32imc-unknown-none-elf
 
     - name: Run tests
       run: cargo test --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,11 @@ version = "0.3"
 optional = true
 features = ["arbitrary-derive"]
 
+[dependencies.ring]
+version = "0.16.11"
+optional = true
+default-features = false
+
 [dependencies.serde]
 version = "1.0"
 optional = true
@@ -35,7 +40,7 @@ features = ["derive"]
 ring = "0.16.11"
 
 [features]
-default = ["std"]
+default = ["std", "ring"]
 
 # Enables deriving `arbitrary::Arbitrary` for various manticore types.
 arbitrary-derive = ["libfuzzer-sys", "std"]
@@ -44,4 +49,5 @@ arbitrary-derive = ["libfuzzer-sys", "std"]
 std = [
   "arrayvec/std",
   "byteorder/std",
+  "ring/std",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,5 +35,13 @@ features = ["derive"]
 ring = "0.16.11"
 
 [features]
+default = ["std"]
+
 # Enables deriving `arbitrary::Arbitrary` for various manticore types.
-arbitrary-derive = ["libfuzzer-sys"]
+arbitrary-derive = ["libfuzzer-sys", "std"]
+
+# Enables features that requires the full standard library.
+std = [
+  "arrayvec/std",
+  "byteorder/std",
+]

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -30,11 +30,19 @@
 //! a lot of them have the same name. Instead, use imports like
 //! `use manticore::crypto::sha256;` and partially-qualified names like
 //! `sha256::Hasher`.
+//!
+//! Software implementations of thes traits are provided under the
+//! [`ring` module], based on the [`ring`] crate. Their presence is controlled
+//! by the `ring` feature flag; some opeartions require `std` as well.
+//!
+//! [`ring` module]: ring/index.html
+//! [`ring`]: https://github.com/briansmith/ring
 
 pub mod rsa;
 pub mod sha256;
 
-#[cfg(test)]
+#[cfg(feature = "ring")]
 pub mod ring;
+
 #[cfg(test)]
 pub(crate) mod testdata;

--- a/src/crypto/ring/mod.rs
+++ b/src/crypto/ring/mod.rs
@@ -1,0 +1,25 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Implementations of crypto traits, using the [`ring`] crate.
+//!
+//! This module provides software implemenations of [`crypto`] traits suitable
+//! for use in non-integration uses of `manticore`, such as in tools that talk
+//! to a `manticore` integration. In particular, some submodules have
+//! dependencies on the `std` feature flag.
+//!
+//! Types in this module, much like those in [`crypto`], should not be imported
+//! directly. Instead, names such as `ring::rsa::Keypair` should be used
+//! instead.
+//!
+//! The [`ring` warranty disclaimer] applies to this module as well.
+//!
+//! [`ring`]: https://github.com/briansmith/ring
+//! [`crypto`]: ../index.html
+//! [`ring` warranty disclaimer]: https://github.com/briansmith/ring/blob/main/README.md
+
+pub mod sha256;
+
+#[cfg(feature = "std")]
+pub mod rsa;

--- a/src/crypto/ring/sha256.rs
+++ b/src/crypto/ring/sha256.rs
@@ -1,0 +1,88 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Implementations of [`crypto::sha256`] based on `ring`.
+//!
+//! [`crypto::sha256`]: ../../sha256/index.html
+
+use core::convert::Infallible;
+
+use ring::digest;
+
+use crate::crypto::sha256;
+
+/// A `ring`-based [`sha256::Builder`].
+///
+/// [`sha256::Builder`]: ../../sha256/trait.Builder.html
+pub struct Builder {
+    _priv: (),
+}
+
+impl Builder {
+    /// Creates a new `Builder`.
+    pub fn new() -> Self {
+        Self { _priv: () }
+    }
+}
+
+impl sha256::Builder for Builder {
+    type Hasher = Hasher;
+
+    fn new_hasher(&self) -> Result<Hasher, Infallible> {
+        Ok(Hasher {
+            ctx: digest::Context::new(&digest::SHA256),
+        })
+    }
+}
+
+/// A `ring`-based [`sha256::Hasher`].
+///
+/// See [`ring::sha256::Builder`].
+///
+/// [`sha256::Hasher`]: ../../sha256/trait.Hasher.html
+/// [`ring::sha256::Builder`]: struct.Builder.html
+pub struct Hasher {
+    ctx: digest::Context,
+}
+
+impl sha256::Hasher for Hasher {
+    type Error = Infallible;
+
+    fn write(&mut self, bytes: &[u8]) -> Result<(), Infallible> {
+        self.ctx.update(bytes);
+        Ok(())
+    }
+
+    fn finish(self, out: &mut sha256::Digest) -> Result<(), Infallible> {
+        let digest = self.ctx.finish();
+        out.copy_from_slice(digest.as_ref());
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::crypto::sha256;
+    use crate::crypto::sha256::Builder as _;
+    use crate::crypto::sha256::Hasher as _;
+    use crate::crypto::testdata;
+
+    #[test]
+    fn sha() {
+        let sha = Builder::new();
+        let mut digest = sha256::Digest::default();
+
+        let mut hasher = sha.new_hasher().unwrap();
+        hasher.write(testdata::PLAIN_TEXT).unwrap();
+        hasher.finish(&mut digest).unwrap();
+        assert_eq!(&digest, testdata::PLAIN_SHA256);
+
+        let mut hasher = sha.new_hasher().unwrap();
+        hasher.write(&testdata::PLAIN_TEXT[..16]).unwrap();
+        hasher.write(&testdata::PLAIN_TEXT[16..]).unwrap();
+        hasher.finish(&mut digest).unwrap();
+        assert_eq!(&digest, testdata::PLAIN_SHA256);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,9 +20,24 @@
 //! be used with any packet layer, such as MCTP, TCP, or ring-buffer IPC. See
 //! the [`protocol` module] for more details.
 //!
+//! # Feature flags
+//!
+//! `manticore` provides a number of optional features that can be controlled
+//! through feature flags:
+//! - `std` (default) pulls in the full Rust standard library. This is
+//!   not necessary for any on-device use-cases, but is available for using
+//!   `manticore` as a library for talking to Cerberus devices.
+//! - `ring` (default) enables the [`crypto::ring` module], which provides
+//!   software implementations for cryptography traits used by `manticore`.
+//!   This feature is not intended for on-device use-cases either.
+//! - `serde` enables implementations of `serde`'s (de)serialization traits.
+//! - `arbitrary-derive` enables implementations of fuzz-testing-related
+//!   traits.
+//!
 //! [Cerberus]:
 //!   https://github.com/opencomputeproject/Project_Olympus/tree/master/Project_Cerberus
 //! [`protocol` module]: protocol/index.html
+//! [`crypto::ring` module]: crypto/ring/index.html
 
 #![cfg_attr(not(feature = "std"), no_std)]
 #![deny(missing_docs)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@
 //!   https://github.com/opencomputeproject/Project_Olympus/tree/master/Project_Cerberus
 //! [`protocol` module]: protocol/index.html
 
-#![cfg_attr(not(any(test, feature = "arbitrary-derive")), no_std)]
+#![cfg_attr(not(feature = "std"), no_std)]
 #![deny(missing_docs)]
 #![deny(warnings)]
 #![deny(unused)]

--- a/src/manifest/mod.rs
+++ b/src/manifest/mod.rs
@@ -263,11 +263,12 @@ mod test {
     #[test]
     fn parse_manifest() {
         let keypair =
-            ring::RsaKeypair::from_pkcs8(testdata::RSA_2048_PRIV_PKCS8)
+            ring::rsa::Keypair::from_pkcs8(testdata::RSA_2048_PRIV_PKCS8)
                 .unwrap();
         let pub_key = keypair.public();
-        let mut signer = ring::Rsa.new_signer(keypair).unwrap();
-        let mut rsa = ring::Rsa.new_engine(pub_key).unwrap();
+        let rsa_builder = ring::rsa::Builder::new();
+        let mut signer = rsa_builder.new_signer(keypair).unwrap();
+        let mut rsa = rsa_builder.new_engine(pub_key).unwrap();
 
         let mut manifest = MANIFEST_HEADER.to_vec();
         manifest.extend_from_slice(MANIFEST_CONTENTS);
@@ -286,11 +287,12 @@ mod test {
     #[test]
     fn parse_manifest_too_short() {
         let keypair =
-            ring::RsaKeypair::from_pkcs8(testdata::RSA_2048_PRIV_PKCS8)
+            ring::rsa::Keypair::from_pkcs8(testdata::RSA_2048_PRIV_PKCS8)
                 .unwrap();
         let pub_key = keypair.public();
-        let mut signer = ring::Rsa.new_signer(keypair).unwrap();
-        let mut rsa = ring::Rsa.new_engine(pub_key).unwrap();
+        let rsa_builder = ring::rsa::Builder::new();
+        let mut signer = rsa_builder.new_signer(keypair).unwrap();
+        let mut rsa = rsa_builder.new_engine(pub_key).unwrap();
 
         let mut manifest = MANIFEST_HEADER.to_vec();
         manifest.extend_from_slice(&MANIFEST_CONTENTS[1..]);
@@ -307,11 +309,12 @@ mod test {
     #[test]
     fn parse_manifest_bad_sig() {
         let keypair =
-            ring::RsaKeypair::from_pkcs8(testdata::RSA_2048_PRIV_PKCS8)
+            ring::rsa::Keypair::from_pkcs8(testdata::RSA_2048_PRIV_PKCS8)
                 .unwrap();
         let pub_key = keypair.public();
-        let mut signer = ring::Rsa.new_signer(keypair).unwrap();
-        let mut rsa = ring::Rsa.new_engine(pub_key).unwrap();
+        let rsa_builder = ring::rsa::Builder::new();
+        let mut signer = rsa_builder.new_signer(keypair).unwrap();
+        let mut rsa = rsa_builder.new_engine(pub_key).unwrap();
 
         let mut manifest = MANIFEST_HEADER.to_vec();
         manifest.extend_from_slice(MANIFEST_CONTENTS);

--- a/src/server/pa_rot.rs
+++ b/src/server/pa_rot.rs
@@ -212,7 +212,7 @@ mod test {
 
     fn simulate_request<'a, C: protocol::Command<'a>>(
         scratch_space: &'a mut [u8],
-        server: &mut PaRot<fake::Identity, fake::Reset, ring::Rsa>,
+        server: &mut PaRot<fake::Identity, fake::Reset, ring::rsa::Builder>,
         request: C::Req,
     ) -> Result<C::Resp, Error> {
         let mut cursor = Cursor::new(scratch_space);
@@ -243,7 +243,7 @@ mod test {
     fn sanity() {
         let identity = fake::Identity::new(b"test version", b"random bits");
         let reset = fake::Reset::new(0, Duration::from_millis(1));
-        let rsa = ring::Rsa;
+        let rsa = ring::rsa::Builder::new();
         let mut server = PaRot::new(Options {
             identity: &identity,
             reset: &reset,


### PR DESCRIPTION
This PR also moves around some Cargo features. In particular, `std` and `ring` are both included by default, because they are necessary for tests (Cargo does not allow specifying additional test-only features, and this behavior seems consistent with other crates).