### PR TITLE
[tool] Clean up manticore-tool

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,9 +20,8 @@ byteorder = { version = "1.3.4", default_features = false }
 static_assertions = "1.1.0"
 zerocopy = "0.3.0"
 
-[dependencies.clap]
-version = "2.33.1"
-optional = true
+serde_json = { version = "1.0", optional = true }
+structopt = { version = "0.3.16", optional = true }
 
 [dependencies.libfuzzer-sys]
 version = "0.3"
@@ -39,10 +38,6 @@ version = "1.0"
 optional = true
 default-features = false
 features = ["derive"]
-
-[dependencies.serde_json]
-version = "1.0"
-optional = true
 
 [dev-dependencies]
 ring = "0.16.11"
@@ -61,9 +56,9 @@ std = [
 ]
 
 tool = [
-  "clap",
   "serde",
   "serde_json",
+  "structopt",
 ]
 
 [[bin]]

--- a/src/protocol/wire.rs
+++ b/src/protocol/wire.rs
@@ -13,6 +13,8 @@
 //! [`ToWire`]: trait.ToWire.html
 //! [`serde`]: https://serde.rs
 
+use core::fmt;
+
 use crate::io;
 use crate::io::endian::LeInt;
 use crate::io::Read;
@@ -150,6 +152,12 @@ where
 /// A deserialization-from-string error.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 pub struct WireEnumFromStrError;
+
+impl fmt::Display for WireEnumFromStrError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "unknown variant")
+    }
+}
 
 /// A conveinence macro for generating `WireEnum`-implementing enums.
 ///


### PR DESCRIPTION
This change simplifies some of the code in manticore-tool, to make it easier to add more commands in the future.

This probably aught to have been broken up into multiple commits but it wound up being more work than was worth it. =/