### PR TITLE
Move `manifest::Container` to a new, buffer-free API

### DIFF
--- a/src/hardware/flash.rs
+++ b/src/hardware/flash.rs
@@ -2,47 +2,21 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Pluggable hardware functionality
+//! External, remote flash abstraction.
 //!
-//! This module provides traits for plugging in OS calls to specialized
-//! hardware functions, such as power-on and reset-related capabilities.
-//! `manticore` uses this functionality to respond to certain protocol
-//! requests.
-
-use core::time::Duration;
+//! This crate provides the [`Flash`] (and related) traits, which represent
+//! *abstract flash devices*. An abstract flash device is a region of memory
+//! that can be transactionally read or written. Such a "device" can range
+//! from a simple Rust slice to a remote SPI flash device (or even a subregion of
+//! it!).
+//!
+//! [`Flash`]: trait.Flash.html
 
 use zerocopy::AsBytes;
 use zerocopy::FromBytes;
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
-
-/// Provides access to "chip identity" information of various types.
-pub trait Identity {
-    /// Returns a string indicating the RoT's firmware version.
-    ///
-    /// Although not enforced, it is recommended that this be an ASCII string.
-    fn firmware_version(&self) -> &[u8; 32];
-
-    /// Returns the "unique device identity" for the device. This is a binary
-    /// value of unspecified format.
-    fn unique_device_identity(&self) -> &[u8];
-}
-
-/// Provides access to device reset-related information for a particular
-/// device.
-pub trait Reset {
-    /// Returns the number of times the device has been reset since it was
-    /// powered on.
-    fn resets_since_power_on(&self) -> u32;
-
-    /// Returns the uptime of the device, i.e., the absolute duration since it
-    /// was last released from reset.
-    ///
-    /// The resolution and accuracy of this value are expected to be
-    /// best-effort.
-    fn uptime(&self) -> Duration;
-}
 
 /// Provides access to a flash-like storage device.
 ///
@@ -51,8 +25,7 @@ pub trait Reset {
 /// to implement these operations efficiently with respect to the underlying
 /// device.
 ///
-/// `Flash` is also implemented on main-memory `u8` buffers, which can be used
-/// for testing.
+/// The `Flash` trait comes implemented for `[u8]`.
 pub trait Flash {
     /// The error type returned by transactions with this `Flash`.
     type Error: Sized;
@@ -87,7 +60,7 @@ pub struct FlashPtr {
 
 impl FlashPtr {
     /// Convenience method for creating a `FlashPtr` without having to use
-    /// a struct literal
+    /// a struct literal.
     pub const fn new(address: u32) -> Self {
         Self { address }
     }
@@ -145,65 +118,5 @@ impl Flash for [u8] {
         }
         out.copy_from_slice(&self[start..end]);
         Ok(())
-    }
-}
-
-#[cfg(test)]
-pub(crate) mod fake {
-    use core::convert::TryInto;
-    use core::time::Duration;
-
-    /// A fake `Identity` that returns fixed values.
-    pub struct Identity {
-        firmware_version: Vec<u8>,
-        unique_id: Vec<u8>,
-    }
-
-    impl Identity {
-        /// Creates a new `fake::Identity`.
-        pub fn new(firmware_version: &[u8], unique_id: &[u8]) -> Self {
-            let mut firmware_version = firmware_version.to_vec();
-            while firmware_version.len() < 32 {
-                firmware_version.push(0);
-            }
-            firmware_version.truncate(32);
-
-            Self {
-                firmware_version,
-                unique_id: unique_id.to_vec(),
-            }
-        }
-    }
-
-    impl super::Identity for Identity {
-        fn firmware_version(&self) -> &[u8; 32] {
-            self.firmware_version[..32].try_into().unwrap()
-        }
-        fn unique_device_identity(&self) -> &[u8] {
-            &self.unique_id[..]
-        }
-    }
-
-    /// A fake `Reset` that returns fixed values.
-    pub struct Reset {
-        resets: u32,
-        uptime: Duration,
-    }
-
-    impl Reset {
-        /// Creates a new `fake::Reset`.
-        pub fn new(resets: u32, uptime: Duration) -> Self {
-            Self { resets, uptime }
-        }
-    }
-
-    impl super::Reset for Reset {
-        fn resets_since_power_on(&self) -> u32 {
-            self.resets
-        }
-
-        fn uptime(&self) -> Duration {
-            self.uptime
-        }
     }
 }

--- a/src/hardware/flash.rs
+++ b/src/hardware/flash.rs
@@ -12,11 +12,42 @@
 //!
 //! [`Flash`]: trait.Flash.html
 
+use core::convert::TryInto;
+
+use static_assertions::assert_obj_safe;
+
 use zerocopy::AsBytes;
 use zerocopy::FromBytes;
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
+
+use crate::io;
+use crate::mem::Arena;
+
+/// A [`Flash`] error.
+///
+/// All of these errors are non-retryable; a [`Flash`] implementation should
+/// block until the operation succeeds.
+///
+/// [`Flash`]: trait.Flash.html
+#[derive(Copy, Clone, Debug)]
+pub enum Error {
+    /// Indicates that an operation failed because the requested
+    /// operation was outside of the device's address space.
+    OutOfRange,
+
+    /// Indicates that the device is locked in some manner and cannot
+    /// be affected by the operation.
+    Locked,
+
+    /// Indicates that an internal invariant was violated, such as running out
+    /// of memory.
+    Internal,
+
+    /// Indicates that an unspecified error occured.
+    Unspecified,
+}
 
 /// Provides access to a flash-like storage device.
 ///
@@ -27,21 +58,194 @@ use serde::{Deserialize, Serialize};
 ///
 /// The `Flash` trait comes implemented for `[u8]`.
 pub trait Flash {
-    /// The error type returned by transactions with this `Flash`.
-    type Error: Sized;
+    /// Returns the size, in bytes, of this device.
+    fn size(&self) -> Result<u32, Error>;
 
-    /// Gets the size, in bytes, of this device.
-    fn size(&self) -> Result<u32, Self::Error>;
+    /// Attempts to read `out.len()` bytes starting at `offset`.
+    fn read(&self, offset: FlashPtr, out: &mut [u8]) -> Result<(), Error>;
 
-    /// Attempt to read `slice` into `out`.
+    /// Attempts to write `out.len()` bytes starting at `offset`.
     ///
-    /// If `out` is smaller than `slice.len`, only the first `out.len()` bytes
-    /// will be read.
-    fn read(
-        &self,
-        slice: FlashSlice,
-        out: &mut [u8],
-    ) -> Result<(), Self::Error>;
+    /// Note that this function is not guaranteed to succeed (and be
+    /// reflected in the return value of `read`) until `flush()` is called.
+    /// This is to permit a `Flash` implementation to buffer writes before
+    /// sending them out.
+    ///
+    /// Implementations are, as an optimization, permitted to assume that
+    /// writes will be serial and localized, so as to minimize clearing
+    /// operations on flash hardware.
+    fn program(&mut self, offset: FlashPtr, buf: &[u8]) -> Result<(), Error>;
+
+    /// Flushes any pending `program()` operations.
+    fn flush(&mut self) -> Result<(), Error> {
+        Ok(())
+    }
+}
+assert_obj_safe!(Flash);
+
+impl<F: Flash> Flash for &mut F {
+    #[inline]
+    fn size(&self) -> Result<u32, Error> {
+        F::size(self)
+    }
+
+    #[inline]
+    fn read(&self, offset: FlashPtr, out: &mut [u8]) -> Result<(), Error> {
+        F::read(self, offset, out)
+    }
+
+    #[inline]
+    fn program(&mut self, offset: FlashPtr, buf: &[u8]) -> Result<(), Error> {
+        F::program(self, offset, buf)
+    }
+
+    #[inline]
+    fn flush(&mut self) -> Result<(), Error> {
+        F::flush(self)
+    }
+}
+
+/// A [`Flash`] type that allows for zero-copy reads.
+///
+/// This trait allows implementations that can support a zero-copy read,
+/// perhaps due to their inherently-buffering nature, to do so directly.
+///
+/// Normal [`Flash`] implementations can be made to support zero-copy
+/// reads by combining them with an [`Arena`]; see [`ArenaFlash`].
+///
+/// `[u8]` implements this trait with no overhead.
+///
+/// [`Flash`]: trait.Flash.html
+/// [`ArenaFlash]: struct.ArenaFlash.html
+pub trait FlashZero: Flash {
+    /// Attempts to zero-copy read the given region out of this device.
+    fn read_zerocopy(&self, slice: FlashSlice) -> Result<&[u8], Error>;
+
+    /// Hints to the implementation that it can release any buffered contents
+    /// it is currently holding.
+    ///
+    /// See [`Arena::reset()`].
+    ///
+    /// [`Arena::reset()`]: ../../mem/trait.Arena.html#tymethod.reset
+    fn reset(&mut self) -> Result<(), Error> {
+        Ok(())
+    }
+}
+assert_obj_safe!(FlashZero);
+
+impl<F: FlashZero> FlashZero for &mut F {
+    #[inline]
+    fn read_zerocopy(&self, slice: FlashSlice) -> Result<&[u8], Error> {
+        F::read_zerocopy(self, slice)
+    }
+
+    #[inline]
+    fn reset(&mut self) -> Result<(), Error> {
+        F::reset(self)
+    }
+}
+
+/// Shim for supporting "zero-copy" reads on a [`Flash`] via an [`Arena`].
+///
+/// This type wraps a [`Flash`] type, plus an [`Arena`], and implements
+/// zero-copy reads by first allocating a buffer on the arena and then
+/// using that allocation to perform a read.
+///
+/// [`Flash`]: trait.Flash.html
+/// [`Arena`]: ../../mem/trait.Arena.html
+pub struct ArenaFlash<F, A>(pub F, pub A);
+
+impl<F: Flash, A> Flash for ArenaFlash<F, A> {
+    #[inline]
+    fn size(&self) -> Result<u32, Error> {
+        self.0.size()
+    }
+
+    #[inline]
+    fn read(&self, offset: FlashPtr, out: &mut [u8]) -> Result<(), Error> {
+        self.0.read(offset, out)
+    }
+
+    #[inline]
+    fn program(&mut self, offset: FlashPtr, buf: &[u8]) -> Result<(), Error> {
+        self.0.program(offset, buf)
+    }
+
+    #[inline]
+    fn flush(&mut self) -> Result<(), Error> {
+        self.0.flush()
+    }
+}
+
+impl<F: Flash, A: Arena> FlashZero for ArenaFlash<F, A> {
+    fn read_zerocopy(&self, slice: FlashSlice) -> Result<&[u8], Error> {
+        let Self(flash, arena) = self;
+        let buf = arena
+            .alloc(slice.len as usize)
+            .map_err(|_| Error::Internal)?;
+        flash.read(slice.ptr, buf)?;
+        Ok(buf)
+    }
+
+    #[inline]
+    fn reset(&mut self) -> Result<(), Error> {
+        Ok(self.1.reset())
+    }
+}
+
+/// A [`Read`]/[`Write`] implementation for operating on a [`Flash`] serially.
+///
+/// [`Read`]: ../../io/read/trait.Read.html
+/// [`Write`]: ../../io/write/trait.Write.html
+/// [`Flash`]: trait.Flash.html
+pub struct FlashIo<F> {
+    flash: F,
+    cursor: u32,
+    len: u32,
+}
+
+impl<F: Flash> FlashIo<F> {
+    /// Creates a new `FlashIo`, reading/writing from the beginning of `flash`.
+    pub fn new(flash: F) -> Result<Self, Error> {
+        let len = flash.size()?;
+        Ok(Self {
+            flash,
+            cursor: 0,
+            len,
+        })
+    }
+
+    /// Skips the cursor `bytes` bytes forward.
+    ///
+    /// This operation always succeeds, but attempting to read past the end of
+    /// flash will always result in an error.
+    pub fn skip(&mut self, bytes: usize) {
+        self.cursor = self.cursor.saturating_add(bytes as u32);
+    }
+}
+
+impl<F: Flash> io::Read for FlashIo<F> {
+    fn read_bytes(&mut self, out: &mut [u8]) -> Result<(), io::Error> {
+        self.flash
+            .read(FlashPtr::new(self.cursor), out)
+            .map_err(|_| io::Error::Internal)?;
+        self.cursor += out.len() as u32;
+        Ok(())
+    }
+
+    fn remaining_data(&self) -> usize {
+        self.len.saturating_sub(self.cursor) as usize
+    }
+}
+
+impl<F: Flash> io::Write for FlashIo<F> {
+    fn write_bytes(&mut self, buf: &[u8]) -> Result<(), io::Error> {
+        self.flash
+            .program(FlashPtr::new(self.cursor), buf)
+            .map_err(|_| io::Error::Internal)?;
+        self.cursor += buf.len() as u32;
+        Ok(())
+    }
 }
 
 /// An abstract pointer into a [`Flash`] type.
@@ -100,23 +304,43 @@ impl FlashSlice {
 pub struct OutOfBounds;
 
 impl Flash for [u8] {
-    type Error = OutOfBounds;
-
-    fn size(&self) -> Result<u32, Self::Error> {
-        Ok(self.len() as u32)
+    fn size(&self) -> Result<u32, Error> {
+        self.len().try_into().map_err(|_| Error::Unspecified)
     }
 
-    fn read(
-        &self,
-        slice: FlashSlice,
-        out: &mut [u8],
-    ) -> Result<(), Self::Error> {
-        let start = slice.ptr.address as usize;
-        let end = start + slice.len as usize;
-        if start >= self.len() || end > self.len() {
-            return Err(OutOfBounds);
+    fn read(&self, offset: FlashPtr, out: &mut [u8]) -> Result<(), Error> {
+        let start = offset.address as usize;
+        let end = start.checked_add(out.len()).ok_or(Error::OutOfRange)?;
+        if end >= self.len() {
+            return Err(Error::OutOfRange);
         }
+
         out.copy_from_slice(&self[start..end]);
         Ok(())
+    }
+
+    fn program(&mut self, offset: FlashPtr, buf: &[u8]) -> Result<(), Error> {
+        let start = offset.address as usize;
+        let end = start.checked_add(buf.len()).ok_or(Error::OutOfRange)?;
+        if end >= self.len() {
+            return Err(Error::OutOfRange);
+        }
+
+        self[start..end].copy_from_slice(buf);
+        Ok(())
+    }
+}
+
+impl FlashZero for [u8] {
+    fn read_zerocopy(&self, offset: FlashSlice) -> Result<&[u8], Error> {
+        let start = offset.ptr.address as usize;
+        let end = start
+            .checked_add(offset.len as usize)
+            .ok_or(Error::OutOfRange)?;
+        if end >= self.len() {
+            return Err(Error::OutOfRange);
+        }
+
+        Ok(&self[start..end])
     }
 }

--- a/src/manifest/fpm.rs
+++ b/src/manifest/fpm.rs
@@ -70,7 +70,7 @@ use core::mem::size_of;
 use arrayvec::ArrayVec;
 
 use crate::crypto::sha256;
-use crate::hardware::FlashSlice;
+use crate::hardware::flash::FlashSlice;
 use crate::io;
 use crate::io::Read as _;
 use crate::manifest::container::Container;

--- a/src/manifest/fpm.rs
+++ b/src/manifest/fpm.rs
@@ -70,7 +70,7 @@ use core::mem::size_of;
 use arrayvec::ArrayVec;
 
 use crate::crypto::sha256;
-use crate::hardware::flash::FlashSlice;
+use crate::hardware::flash;
 use crate::io;
 use crate::io::Read as _;
 use crate::manifest::container::Container;
@@ -166,7 +166,7 @@ pub struct FwVersion<'m> {
     /// would be stored. To check that this is the firmware version loaded into
     /// the storage device, the value at this address should be compared with
     /// `version_id`.
-    pub version_region: FlashSlice,
+    pub version_region: flash::Region,
     /// This firmware's version string.
     #[cfg_attr(
         all(feature = "inject-alloc", feature = "serde"),
@@ -176,9 +176,9 @@ pub struct FwVersion<'m> {
 
     /// The "signed" region, represented as a list of slices in a storage
     /// device.
-    pub signed_region: Cow<'m, [FlashSlice]>,
+    pub signed_region: Cow<'m, [flash::Region]>,
     /// The "write" region, represented as a list of slices in a storage device.
-    pub write_region: Cow<'m, [FlashSlice]>,
+    pub write_region: Cow<'m, [flash::Region]>,
     /// The "unused region blank byte". Every byte in the unused region is
     /// expected to have this value.
     pub blank_byte: u8,
@@ -227,7 +227,7 @@ impl<'m, Provenance> Fpm<'m, Provenance> {
 
             fpm.versions
                 .try_push(FwVersion {
-                    version_region: FlashSlice::new(
+                    version_region: flash::Region::new(
                         version_addr,
                         version_len as u32,
                     ),
@@ -330,13 +330,13 @@ mod test {
         // NOTE: writing this as a constant forces const-promotion of the
         // slice definitions inside.
         const VERSION: FwVersion = FwVersion {
-            version_region: FlashSlice::new(0x22, 5),
+            version_region: flash::Region::new(0x22, 5),
             version: Cow::Borrowed(&[1, 2, 3, 4, 5]),
             signed_region: Cow::Borrowed(&[
-                FlashSlice::new(0x0, 256),
-                FlashSlice::new(0x200, 55),
+                flash::Region::new(0x0, 256),
+                flash::Region::new(0x200, 55),
             ]),
-            write_region: Cow::Borrowed(&[FlashSlice::new(0x400, 100)]),
+            write_region: Cow::Borrowed(&[flash::Region::new(0x400, 100)]),
             blank_byte: 0xee,
             signed_region_hash: Cow::Borrowed(&[0xa5; 32]),
         };

--- a/src/manifest/mod.rs
+++ b/src/manifest/mod.rs
@@ -8,6 +8,7 @@
 //! configuration of a system it protects, and to describe policies on what
 //! firmware can run on those systems.
 
+use crate::hardware::flash;
 use crate::io;
 
 pub mod container;
@@ -33,6 +34,10 @@ pub enum Error {
     ///
     /// [`io`]: ../io/index.html
     Io(io::Error),
+    /// Indicates that an error occured in a [`flash`] type.
+    ///
+    /// [`flash`]: ../hardware/flash/html
+    Flash(flash::Error),
     /// Indicates that a value was out of its expected range.
     OutOfRange,
     /// Indicates that some assumption about a manifest's alignment (internal
@@ -45,6 +50,12 @@ pub enum Error {
 impl From<io::Error> for Error {
     fn from(e: io::Error) -> Self {
         Self::Io(e)
+    }
+}
+
+impl From<flash::Error> for Error {
+    fn from(e: flash::Error) -> Self {
+        Self::Flash(e)
     }
 }
 


### PR DESCRIPTION
This change lays the groundwork for doing "non-buffering" manifest operations, and, eventually, manifest activation.

Manifests are expected to live off-device, and expecting to be able to buffer all of a manifest at any given time is too stringent of a requirement. In a followup, we will expand this support to the FPM.