### PR TITLE
[flash/mem] Significant changes to how Manticore does memory management

### DIFF
--- a/src/hardware/flash.rs
+++ b/src/hardware/flash.rs
@@ -24,7 +24,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::io;
 use crate::mem::Arena;
-use crate::mem::ArenaExt as _;
+use crate::mem::OutOfMemory;
 
 /// A [`Flash`] error.
 ///
@@ -50,6 +50,12 @@ pub enum Error {
     Unspecified,
 }
 
+impl From<OutOfMemory> for Error {
+    fn from(_: OutOfMemory) -> Error {
+        Error::Internal
+    }
+}
+
 /// Provides access to a flash-like storage device.
 ///
 /// This trait provides abstract operations on a device, as if it were a
@@ -62,6 +68,42 @@ pub trait Flash {
 
     /// Attempts to read `out.len()` bytes starting at `offset`.
     fn read(&self, offset: Ptr, out: &mut [u8]) -> Result<(), Error>;
+
+    /// Attempts to perform a "direct read" of the given `Region`.
+    ///
+    /// This function provides an optimization opportunity to implementations.
+    /// Some implementations, such as [`Ram`], already hold all of their
+    /// contents in memory and so can return a reference into themselves;
+    /// however, physically external flash may not have such a choice. Thus,
+    /// an arena must be passed in to provide for the possiblity of an
+    /// allocation requirement.
+    ///
+    /// This function is not provided with a default implementation, though
+    /// the following should be a sufficient starting point:
+    /// ```
+    /// # use manticore::mem::*;
+    /// # use manticore::hardware::flash::*;
+    /// # struct Foo;
+    /// # impl Foo {
+    /// # fn read(&self, offset: Ptr, out: &mut [u8]) -> Result<(), Error> {
+    /// #   Ok(())
+    /// # }
+    /// fn read_direct<'a: 'c, 'b: 'c, 'c>(
+    ///     &'a self,
+    ///     region: Region,
+    ///     arena: &'b dyn Arena
+    /// ) -> Result<&'c [u8], Error> {
+    ///     let mut buf = arena.alloc_slice::<u8>(region.len as usize)?;
+    ///     self.read(region.ptr, &mut buf)?;
+    ///     Ok(buf)
+    /// }
+    /// # }
+    /// ```
+    fn read_direct<'a: 'c, 'b: 'c, 'c>(
+        &'a self,
+        region: Region,
+        arena: &'b dyn Arena,
+    ) -> Result<&'c [u8], Error>;
 
     /// Attempts to write `out.len()` bytes starting at `offset`.
     ///
@@ -94,6 +136,15 @@ impl<F: Flash> Flash for &F {
     }
 
     #[inline]
+    fn read_direct<'a: 'c, 'b: 'c, 'c>(
+        &'a self,
+        region: Region,
+        arena: &'b dyn Arena,
+    ) -> Result<&'c [u8], Error> {
+        F::read_direct(self, region, arena)
+    }
+
+    #[inline]
     fn program(&mut self, _: Ptr, _: &[u8]) -> Result<(), Error> {
         Err(Error::Locked)
     }
@@ -116,6 +167,15 @@ impl<F: Flash> Flash for &mut F {
     }
 
     #[inline]
+    fn read_direct<'a: 'c, 'b: 'c, 'c>(
+        &'a self,
+        region: Region,
+        arena: &'b dyn Arena,
+    ) -> Result<&'c [u8], Error> {
+        F::read_direct(self, region, arena)
+    }
+
+    #[inline]
     fn program(&mut self, offset: Ptr, buf: &[u8]) -> Result<(), Error> {
         F::program(self, offset, buf)
     }
@@ -123,47 +183,6 @@ impl<F: Flash> Flash for &mut F {
     #[inline]
     fn flush(&mut self) -> Result<(), Error> {
         F::flush(self)
-    }
-}
-
-/// A [`Flash`] type that allows for zero-copy reads.
-///
-/// This trait allows implementations that can support a zero-copy read,
-/// perhaps due to their inherently-buffering nature, to do so directly.
-///
-/// Normal [`Flash`] implementations can be made to support zero-copy
-/// reads by combining them with an [`Arena`]; see [`ArenaFlash`].
-///
-/// [`Flash`]: trait.Flash.html
-/// [`ArenaFlash`]: struct.ArenaFlash.html
-pub trait FlashZero: Flash {
-    /// Attempts to zero-copy read the given region out of this device.
-    fn read_zerocopy(&self, slice: Region) -> Result<&[u8], Error>;
-
-    /// Hints to the implementation that it can release any buffered contents
-    /// it is currently holding.
-    ///
-    /// See [`Arena::reset()`].
-    ///
-    /// [`Arena::reset()`]: ../../mem/trait.Arena.html#tymethod.reset
-    fn reset(&mut self) -> Result<(), Error> {
-        Ok(())
-    }
-}
-assert_obj_safe!(FlashZero);
-
-// NOTE: implementing for &impl FlashZero doesn't make sense, because that
-// would result in an unresettable FlashZero.
-
-impl<F: FlashZero> FlashZero for &mut F {
-    #[inline]
-    fn read_zerocopy(&self, slice: Region) -> Result<&[u8], Error> {
-        F::read_zerocopy(self, slice)
-    }
-
-    #[inline]
-    fn reset(&mut self) -> Result<(), Error> {
-        F::reset(self)
     }
 }
 
@@ -225,6 +244,24 @@ impl<F: Flash> Flash for SubFlash<F> {
     }
 
     #[inline]
+    fn read_direct<'a: 'c, 'b: 'c, 'c>(
+        &'a self,
+        region: Region,
+        arena: &'b dyn Arena,
+    ) -> Result<&'c [u8], Error> {
+        if region.ptr.address >= self.1.len {
+            return Err(Error::OutOfRange);
+        }
+        let offset = region
+            .ptr
+            .address
+            .checked_add(self.1.ptr.address)
+            .ok_or(Error::OutOfRange)?;
+
+        self.0.read_direct(Region::new(offset, region.len), arena)
+    }
+
+    #[inline]
     fn program(&mut self, offset: Ptr, buf: &[u8]) -> Result<(), Error> {
         if offset.address >= self.1.len {
             return Err(Error::OutOfRange);
@@ -243,83 +280,12 @@ impl<F: Flash> Flash for SubFlash<F> {
     }
 }
 
-impl<F: FlashZero> FlashZero for SubFlash<F> {
-    #[inline]
-    fn read_zerocopy(&self, slice: Region) -> Result<&[u8], Error> {
-        if slice.ptr.address > self.1.len {
-            return Err(Error::OutOfRange);
-        }
-        let offset = slice
-            .ptr
-            .address
-            .checked_add(self.1.ptr.address)
-            .ok_or(Error::OutOfRange)?;
-
-        self.0.read_zerocopy(Region::new(offset, slice.len))
-    }
-
-    #[inline]
-    fn reset(&mut self) -> Result<(), Error> {
-        self.0.reset()
-    }
-}
-
-/// Adapter for supporting "zero-copy" reads on a [`Flash`] via an [`Arena`].
-///
-/// This type wraps a [`Flash`] type, plus an [`Arena`], and implements
-/// zero-copy reads by first allocating a buffer on the arena and then
-/// using that allocation to perform a read.
-///
-/// [`Flash`]: trait.Flash.html
-/// [`Arena`]: ../../mem/trait.Arena.html
-#[derive(Copy, Clone)]
-pub struct ArenaFlash<F, A>(pub F, pub A);
-
-impl<F: Flash, A> Flash for ArenaFlash<F, A> {
-    #[inline]
-    fn size(&self) -> Result<u32, Error> {
-        self.0.size()
-    }
-
-    #[inline]
-    fn read(&self, offset: Ptr, out: &mut [u8]) -> Result<(), Error> {
-        self.0.read(offset, out)
-    }
-
-    #[inline]
-    fn program(&mut self, offset: Ptr, buf: &[u8]) -> Result<(), Error> {
-        self.0.program(offset, buf)
-    }
-
-    #[inline]
-    fn flush(&mut self) -> Result<(), Error> {
-        self.0.flush()
-    }
-}
-
-impl<F: Flash, A: Arena> FlashZero for ArenaFlash<F, A> {
-    fn read_zerocopy(&self, slice: Region) -> Result<&[u8], Error> {
-        let Self(flash, arena) = self;
-        let buf = arena
-            .alloc_slice::<u8>(slice.len as usize)
-            .map_err(|_| Error::Internal)?;
-        flash.read(slice.ptr, buf)?;
-        Ok(buf)
-    }
-
-    #[inline]
-    fn reset(&mut self) -> Result<(), Error> {
-        self.1.reset();
-        Ok(())
-    }
-}
-
-/// Adapter for converting RAM-backed storage into a [`FlashZero`].
+/// Adapter for converting RAM-backed storage into a [`Flash`].
 ///
 /// For the purposes of this type, "RAM-backed" means that `AsRef<[u8]>`
 /// is implemented.
 ///
-/// [`FlashZero`]: traits.Flash.html
+/// [`Flash`]: traits.Flash.html
 #[derive(Copy, Clone)]
 pub struct Ram<Bytes>(pub Bytes);
 
@@ -332,27 +298,23 @@ impl<Bytes: AsRef<[u8]>> Flash for Ram<Bytes> {
             .map_err(|_| Error::Unspecified)
     }
 
+    #[inline]
     fn read(&self, offset: Ptr, out: &mut [u8]) -> Result<(), Error> {
-        let start = offset.address as usize;
-        let end = start.checked_add(out.len()).ok_or(Error::OutOfRange)?;
-        if end > self.0.as_ref().len() {
-            return Err(Error::OutOfRange);
-        }
-
-        out.copy_from_slice(&self.0.as_ref()[start..end]);
+        out.copy_from_slice(self.read_direct(
+            Region::new(offset.address, out.len() as u32),
+            &OutOfMemory,
+        )?);
         Ok(())
     }
 
-    fn program(&mut self, _: Ptr, _: &[u8]) -> Result<(), Error> {
-        Err(Error::Locked)
-    }
-}
-
-impl<Bytes: AsRef<[u8]>> FlashZero for Ram<Bytes> {
-    fn read_zerocopy(&self, offset: Region) -> Result<&[u8], Error> {
-        let start = offset.ptr.address as usize;
+    fn read_direct<'a: 'c, 'b: 'c, 'c>(
+        &'a self,
+        region: Region,
+        _: &'b dyn Arena,
+    ) -> Result<&'c [u8], Error> {
+        let start = region.ptr.address as usize;
         let end = start
-            .checked_add(offset.len as usize)
+            .checked_add(region.len as usize)
             .ok_or(Error::OutOfRange)?;
         if end > self.0.as_ref().len() {
             return Err(Error::OutOfRange);
@@ -360,14 +322,18 @@ impl<Bytes: AsRef<[u8]>> FlashZero for Ram<Bytes> {
 
         Ok(&self.0.as_ref()[start..end])
     }
+
+    fn program(&mut self, _: Ptr, _: &[u8]) -> Result<(), Error> {
+        Err(Error::Locked)
+    }
 }
 
-/// Adapter for converting mutable, RAM-backed storage into a [`FlashZero`].
+/// Adapter for converting mutable, RAM-backed storage into a [`Flash`].
 ///
 /// For the purposes of this type, "RAM-backed" means that `AsRef<[u8]>`
 /// and `AsMut<[u8]>` are implemented.
 ///
-/// [`FlashZero`]: traits.Flash.html
+/// [`Flash`]: traits.Flash.html
 #[derive(Copy, Clone)]
 pub struct RamMut<Bytes>(pub Bytes);
 
@@ -380,15 +346,29 @@ impl<Bytes: AsRef<[u8]> + AsMut<[u8]>> Flash for RamMut<Bytes> {
             .map_err(|_| Error::Unspecified)
     }
 
+    #[inline]
     fn read(&self, offset: Ptr, out: &mut [u8]) -> Result<(), Error> {
-        let start = offset.address as usize;
-        let end = start.checked_add(out.len()).ok_or(Error::OutOfRange)?;
+        out.copy_from_slice(self.read_direct(
+            Region::new(offset.address, out.len() as u32),
+            &OutOfMemory,
+        )?);
+        Ok(())
+    }
+
+    fn read_direct<'a: 'c, 'b: 'c, 'c>(
+        &'a self,
+        region: Region,
+        _: &'b dyn Arena,
+    ) -> Result<&'c [u8], Error> {
+        let start = region.ptr.address as usize;
+        let end = start
+            .checked_add(region.len as usize)
+            .ok_or(Error::OutOfRange)?;
         if end > self.0.as_ref().len() {
             return Err(Error::OutOfRange);
         }
 
-        out.copy_from_slice(&self.0.as_ref()[start..end]);
-        Ok(())
+        Ok(&self.0.as_ref()[start..end])
     }
 
     fn program(&mut self, offset: Ptr, buf: &[u8]) -> Result<(), Error> {
@@ -400,20 +380,6 @@ impl<Bytes: AsRef<[u8]> + AsMut<[u8]>> Flash for RamMut<Bytes> {
 
         self.0.as_mut()[start..end].copy_from_slice(buf);
         Ok(())
-    }
-}
-
-impl<Bytes: AsRef<[u8]> + AsMut<[u8]>> FlashZero for RamMut<Bytes> {
-    fn read_zerocopy(&self, offset: Region) -> Result<&[u8], Error> {
-        let start = offset.ptr.address as usize;
-        let end = start
-            .checked_add(offset.len as usize)
-            .ok_or(Error::OutOfRange)?;
-        if end > self.0.as_ref().len() {
-            return Err(Error::OutOfRange);
-        }
-
-        Ok(&self.0.as_ref()[start..end])
     }
 }
 

--- a/src/hardware/flash.rs
+++ b/src/hardware/flash.rs
@@ -24,6 +24,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::io;
 use crate::mem::Arena;
+use crate::mem::ArenaExt as _;
 
 /// A [`Flash`] error.
 ///
@@ -300,7 +301,7 @@ impl<F: Flash, A: Arena> FlashZero for ArenaFlash<F, A> {
     fn read_zerocopy(&self, slice: Region) -> Result<&[u8], Error> {
         let Self(flash, arena) = self;
         let buf = arena
-            .alloc(slice.len as usize)
+            .alloc_slice::<u8>(slice.len as usize)
             .map_err(|_| Error::Internal)?;
         flash.read(slice.ptr, buf)?;
         Ok(buf)

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,7 @@ use manticore::manifest::fpm::Fpm;
 use manticore::manifest::provenance;
 use manticore::manifest::ManifestType;
 use manticore::mem::BumpArena;
+use manticore::mem::OutOfMemory;
 use manticore::protocol::firmware_version;
 use manticore::protocol::wire::FromWire;
 use manticore::protocol::wire::ToWire;
@@ -354,6 +355,7 @@ fn main() {
                     Ram(&buf),
                     &sha,
                     &mut engine,
+                    &OutOfMemory,
                 ) {
                     Ok(c) => c,
                     Err(manifest::Error::SignatureFailure) => {
@@ -368,7 +370,7 @@ fn main() {
 
             match container.manifest_type() {
                 ManifestType::Fpm => {
-                    let fpm = Fpm::parse(&container)
+                    let fpm = Fpm::parse(&container, &OutOfMemory)
                         .expect("failed to parse manifest");
                     if pretty {
                         serde_json::to_writer_pretty(output, &fpm)

--- a/src/manifest/container.rs
+++ b/src/manifest/container.rs
@@ -135,7 +135,7 @@ impl<F: Flash> Container<F, provenance::Signed> {
             .finish(&mut digest)
             .map_err(|_| Error::SignatureFailure)?;
 
-        let sig = c.flash.read_direct(sig, arena)?;
+        let sig = c.flash.read_direct(sig, arena, 1)?;
         rsa.verify_signature(sig, &digest)
             .map_err(|_| Error::SignatureFailure)?;
 
@@ -490,7 +490,7 @@ pub(crate) mod test {
         assert_eq!(
             manifest
                 .flash()
-                .read_direct(manifest.body(), &OutOfMemory)
+                .read_direct(manifest.body(), &OutOfMemory, 1)
                 .unwrap(),
             MANIFEST_CONTENTS
         );
@@ -591,7 +591,7 @@ pub(crate) mod test {
         assert_eq!(
             manifest
                 .flash()
-                .read_direct(manifest.body(), &OutOfMemory)
+                .read_direct(manifest.body(), &OutOfMemory, 1)
                 .unwrap(),
             MANIFEST_CONTENTS
         );

--- a/src/manifest/fpm.rs
+++ b/src/manifest/fpm.rs
@@ -255,7 +255,7 @@ impl<'m, Provenance> Fpm<'m, Provenance> {
     pub fn unparse(&self, mut out: impl io::Write) -> Result<(), Error> {
         out.write_le(self.versions.len() as u32)?;
         for version in self.versions() {
-            out.write_le(version.version_region.ptr.address)?;
+            out.write_le(version.version_region.offset)?;
 
             let signed_len: u16 = version
                 .signed_region
@@ -288,11 +288,11 @@ impl<'m, Provenance> Fpm<'m, Provenance> {
             }
 
             for slice in version.signed_region.iter() {
-                out.write_le(slice.ptr.address)?;
+                out.write_le(slice.offset)?;
                 out.write_le(slice.len)?;
             }
             for slice in version.write_region.iter() {
-                out.write_le(slice.ptr.address)?;
+                out.write_le(slice.offset)?;
                 out.write_le(slice.len)?;
             }
             out.write_bytes(&*version.signed_region_hash)?;

--- a/src/manifest/fpm.rs
+++ b/src/manifest/fpm.rs
@@ -202,7 +202,7 @@ impl<'m, Provenance> Fpm<'m, Provenance> {
     ) -> Result<Self, Error> {
         // FIXME(mcyoung): don't read the entire buffer at once.
         let mut body =
-            container.flash().read_direct(container.body(), arena)?;
+            container.flash().read_direct(container.body(), arena, 4)?;
 
         let mut fpm = Self {
             versions: ArrayVec::new(),

--- a/src/mem/arena.rs
+++ b/src/mem/arena.rs
@@ -8,13 +8,21 @@
 
 use core::cell::Cell;
 use core::marker::PhantomData;
+use core::mem;
 use core::ptr::NonNull;
 use core::slice;
 
 use static_assertions::assert_obj_safe;
 
+use zerocopy::AsBytes;
+use zerocopy::FromBytes;
+use zerocopy::LayoutVerified;
+
+use crate::mem::align_to;
+
 /// An error indicating that an [`Arena`] has run out of allocatable
-/// memory.
+/// memory or that memory that is more aligned than is supported
+/// was requested.
 ///
 /// [`Arena`]: trait.Arena.html
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -29,9 +37,18 @@ pub struct OutOfMemory;
 /// See [`BumpArena`] for an illustration of how the borrow checker is used to
 /// do this safely.
 ///
+/// # Safety
+///
+/// `alloc_aligned()` is required to return memory with certain size and
+/// alignment guarantees. While it itself is a safe function, unsafe code
+/// is permitted to rely on these guarantees.
+///
 /// [`BumpArena`]: struct.BumpArena.html
-pub trait Arena {
-    /// Allocate `len` bytes of memory from this arena.
+pub unsafe trait Arena {
+    /// Allocates `len` bytes of `align`-aligned memory from this arena.
+    ///
+    /// This is a low-level function: prefer instead to use the helpers defined
+    /// in [`ArenaExt`].
     ///
     /// This function may be called multiple times, and the returned slices
     /// will be disjoint.
@@ -41,20 +58,30 @@ pub trait Arena {
     /// As such, "poisoned bits", such as the padding bits of Rust structs,
     /// should never be written to memory returned by this function.
     ///
-    /// Calling `alloc(0)` must never fail.
+    /// Calling `alloc(0, 1)` must never fail. Note that there is no
+    /// requirement that calling `alloc(0, n)` will not return a subslice
+    /// of previously returned memory.
     ///
     /// # Panics
+    ///
+    /// This function will panic if `align` is not a power of two.
     ///
     /// This function is permitted to panic under catastrophic failure
     /// conditions, such as completely running out of program memory.
     /// Implementations must advertize whether they panic.
-    fn alloc(&self, len: usize) -> Result<&mut [u8], OutOfMemory>;
+    ///
+    /// [`ArenaExt`]: trait.ArenaExt.html
+    fn alloc_aligned(
+        &self,
+        len: usize,
+        align: usize,
+    ) -> Result<&mut [u8], OutOfMemory>;
 
     /// Resets this arena, essentially freeing all memory that was given out
     /// and allowing it to be allocated once more.
     ///
     /// Calling this function requires that all slices that were given out by
-    /// `alloc()` are unreachable. Hence, this function must take `self` by
+    /// this arena are unreachable. Hence, this function must take `self` by
     /// unique reference: this ensures that no one else is holding references
     /// to the memory inside.
     ///
@@ -66,14 +93,79 @@ pub trait Arena {
     /// # let mut arena = BumpArena::new(&mut data);
     /// // If the first alloc succeeds (regardless of the value of `len`), then
     /// // the subsequent alloc after resetting the arena must also succeed.
-    /// assert!(arena.alloc(64).is_ok());
+    /// assert!(arena.alloc_aligned(64, 1).is_ok());
     /// arena.reset();
-    /// assert!(arena.alloc(64).is_ok());
+    /// assert!(arena.alloc_aligned(64, 1).is_ok());
     /// ```
     fn reset(&mut self);
 }
 
 assert_obj_safe!(Arena);
+
+/// Convenience functions for arenas, exposed as a trait.
+///
+/// Note that this trait is implemened for `&impl Arena`, which is the reason
+/// for the slightly odd signature.
+pub trait ArenaExt<'arena> {
+    /// Allocates a value of type `T`.
+    ///
+    /// Because of the `reset()` function, it needs to be safe to transmute
+    /// `T` back into bytes. As such, There is an additional `AsBytes` bound.
+    /// To avoid having to mess around with destructors, we additionally
+    /// require a `Copy` bound, though this may eventually be removed.
+    ///
+    /// # Panics
+    ///
+    /// This function is permitted to panic under catastrophic failure
+    /// conditions, such as completely running out of program memory.
+    /// Implementations must advertize whether they panic.
+    fn alloc<T>(self) -> Result<&'arena mut T, OutOfMemory>
+    where
+        T: AsBytes + FromBytes + Copy;
+
+    /// Allocates a slice with `n` elements.
+    ///
+    /// Because of the `reset()` function, it needs to be safe to transmute
+    /// `T` back into bytes. As such, There is an additional `AsBytes` bound.
+    /// To avoid having to mess around with destructors, we additionally
+    /// require a `Copy` bound, though this may eventually be removed.
+    ///
+    /// # Panics
+    ///
+    /// This function is permitted to panic under catastrophic failure
+    /// conditions, such as completely running out of program memory.
+    /// Implementations must advertize whether they panic.
+    fn alloc_slice<T>(self, n: usize) -> Result<&'arena mut [T], OutOfMemory>
+    where
+        T: AsBytes + FromBytes + Copy;
+}
+
+impl<'arena, A: Arena + ?Sized> ArenaExt<'arena> for &'arena A {
+    fn alloc<T: AsBytes + FromBytes + Copy>(
+        self,
+    ) -> Result<&'arena mut T, OutOfMemory> {
+        let bytes =
+            self.alloc_aligned(mem::size_of::<T>(), mem::align_of::<T>())?;
+
+        let lv = LayoutVerified::new(bytes)
+            .expect("alloc_aligned() implemented incorrectly");
+        Ok(lv.into_mut())
+    }
+
+    fn alloc_slice<T: AsBytes + FromBytes + Copy>(
+        self,
+        n: usize,
+    ) -> Result<&'arena mut [T], OutOfMemory> {
+        let bytes_requested =
+            mem::size_of::<T>().checked_mul(n).ok_or(OutOfMemory)?;
+        let bytes =
+            self.alloc_aligned(bytes_requested, mem::align_of::<T>())?;
+
+        let lv = LayoutVerified::new_slice(bytes)
+            .expect("alloc_aligned() implemented incorrectly");
+        Ok(lv.into_mut_slice())
+    }
+}
 
 /// A bump-allocating [`Arena`] that is backed by a byte slice.
 ///
@@ -85,13 +177,13 @@ assert_obj_safe!(Arena);
 /// let mut data = [0; 128];
 /// let mut arena = BumpArena::new(&mut data);
 ///
-/// let buf1 = arena.alloc(64)?;
-/// let buf2 = arena.alloc(64)?;
+/// let buf1 = arena.alloc::<[u8; 64]>()?;
+/// let buf2 = arena.alloc_slice::<u8>(64)?;
 /// assert_eq!(buf1.len(), 64);
-/// assert!(arena.alloc(1).is_err());
+/// assert!(arena.alloc_slice::<u8>(1).is_err());
 ///
 /// arena.reset();
-/// let buf3 = arena.alloc(64)?;
+/// let buf3 = arena.alloc_slice::<u8>(64)?;
 /// assert_eq!(buf3.len(), 64);
 /// # Ok::<(), OutOfMemory>(())
 /// ```
@@ -104,7 +196,7 @@ assert_obj_safe!(Arena);
 /// let mut data = [0; 128];
 /// let mut arena = BumpArena::new(&mut data);
 ///
-/// let buf = arena.alloc(64)?;
+/// let buf = arena.alloc_slice::<u8>(64)?;
 /// arena.reset();
 /// buf[0] = 42;  // Does not compile!
 /// # Ok::<(), OutOfMemory>(())
@@ -112,7 +204,7 @@ assert_obj_safe!(Arena);
 ///
 /// # Panics
 ///
-/// `BumpArena::alloc()` will never panic.
+/// `BumpArena::alloc_aligned()` will never panic.
 pub struct BumpArena<'arena> {
     // Even though we do not store `slice`, the lifetime trapped in
     // `lifetime_phantom` ensures that the slice is unaccessible until
@@ -143,10 +235,10 @@ impl<'arena> BumpArena<'arena> {
             cursor: Cell::new(0),
         }
     }
-}
 
-impl<'arena> Arena for BumpArena<'arena> {
-    fn alloc(&self, len: usize) -> Result<&mut [u8], OutOfMemory> {
+    /// Allocates unaligned memory of the given length, moving the cursor
+    /// forward as necessary.
+    fn alloc_raw(&self, len: usize) -> Result<&mut [u8], OutOfMemory> {
         if len == 0 {
             return Ok(&mut []);
         }
@@ -173,6 +265,53 @@ impl<'arena> Arena for BumpArena<'arena> {
         Ok(slice)
     }
 
+    /// Aligns the internal buffer to the given alignment.
+    ///
+    /// # Panics
+    ///
+    /// `align` must be a power of two.
+    fn align_to(&self, align: usize) -> Result<(), OutOfMemory> {
+        assert!(align.is_power_of_two());
+
+        // SAFE: see the safety notes in alloc_raw().
+        let current_addr =
+            unsafe { self.buf_ptr.as_ptr().add(self.cursor.get()) as usize };
+        let aligned = align_to(current_addr, align);
+        if aligned == usize::MAX && align > 1 {
+            // We've hit the top of the address space, so we have no hope of
+            // allocating aligned memory.
+            return Err(OutOfMemory);
+        }
+        let misalignment = aligned - current_addr;
+
+        self.alloc_raw(misalignment)?;
+        Ok(())
+    }
+}
+
+unsafe impl<'arena> Arena for BumpArena<'arena> {
+    fn alloc_aligned(
+        &self,
+        len: usize,
+        align: usize,
+    ) -> Result<&mut [u8], OutOfMemory> {
+        if len == 0 {
+            assert!(align.is_power_of_two());
+            // SAFE: zero-length slices have no restrictions on the pointer
+            // beyond non-null-ness and well-aligned-ness, so we materialize
+            // one out of thin air.
+            //
+            // NonNull::dangling() is optimial, but that required having a
+            // concrete type.
+            return Ok(unsafe {
+                slice::from_raw_parts_mut(align as *mut u8, 0)
+            });
+        }
+
+        self.align_to(align)?;
+        self.alloc_raw(len)
+    }
+
     // NOTE: because this function takes `self` by unique reference, no mutable
     // slices returned by `alloc()` could have survied, since that would require
     // us to hold a reference to `self`.
@@ -181,5 +320,27 @@ impl<'arena> Arena for BumpArena<'arena> {
     // outstanding poitners to alias.
     fn reset(&mut self) {
         self.cursor.set(0)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn complex_alignments() {
+        let mut data = [0; 128];
+        let arena = BumpArena::new(&mut data);
+
+        let buf = arena.alloc_aligned(1, 1).unwrap();
+        assert_eq!(buf.len(), 1);
+
+        let buf = arena.alloc_aligned(1, 4).unwrap();
+        assert_eq!(buf.len(), 1);
+        assert_eq!(buf.as_ptr() as usize % 4, 0);
+
+        let buf = arena.alloc_aligned(0, 4).unwrap();
+        assert_eq!(buf.len(), 0);
+        assert_eq!(buf.as_ptr() as usize % 4, 0);
     }
 }

--- a/src/mem/mod.rs
+++ b/src/mem/mod.rs
@@ -9,3 +9,21 @@ mod arena;
 pub use arena::*;
 
 pub mod cow;
+
+/// Aligns the given address to the alignment for the given type.
+///
+/// `align` must be a power of two; otherwise, the returned value
+/// will be well-defined but unspecified.
+///
+/// This function will always return a value greater than or equal to `addr`.
+/// This invariant is always maintained, even if it would cause an unaligned
+/// value to be returned.
+#[inline]
+pub(in crate) fn align_to(addr: usize, align: usize) -> usize {
+    let mask = align.wrapping_sub(1);
+    let (addr, overflow) = addr.overflowing_add(mask);
+    if overflow {
+        return usize::MAX;
+    }
+    addr & !mask
+}

--- a/src/protocol/device_info.rs
+++ b/src/protocol/device_info.rs
@@ -10,6 +10,7 @@
 use crate::io::Read;
 use crate::io::Write;
 use crate::mem::Arena;
+use crate::mem::ArenaExt as _;
 use crate::protocol::wire::FromWire;
 use crate::protocol::wire::FromWireError;
 use crate::protocol::wire::ToWire;
@@ -106,7 +107,7 @@ impl<'a> FromWire<'a> for DeviceInfoResponse<'a> {
         arena: &'a A,
     ) -> Result<Self, FromWireError> {
         let len = r.remaining_data();
-        let buf = arena.alloc(len)?;
+        let buf = arena.alloc_slice::<u8>(len)?;
         r.read_bytes(buf)?;
         Ok(Self { info: buf })
     }

--- a/src/protocol/firmware_version.rs
+++ b/src/protocol/firmware_version.rs
@@ -12,6 +12,7 @@ use core::convert::TryInto as _;
 use crate::io::Read;
 use crate::io::Write;
 use crate::mem::Arena;
+use crate::mem::ArenaExt as _;
 use crate::protocol::wire::FromWire;
 use crate::protocol::wire::FromWireError;
 use crate::protocol::wire::ToWire;
@@ -114,10 +115,7 @@ impl<'a> FromWire<'a> for FirmwareVersionResponse<'a> {
         mut r: R,
         arena: &'a A,
     ) -> Result<Self, FromWireError> {
-        let version: &mut [u8; 32] = arena
-            .alloc(32)?
-            .try_into()
-            .map_err(|_| FromWireError::OutOfRange)?;
+        let version: &mut [u8; 32] = arena.alloc::<[u8; 32]>()?;
         r.read_bytes(version)?;
         Ok(Self { version })
     }

--- a/src/protocol/firmware_version.rs
+++ b/src/protocol/firmware_version.rs
@@ -7,8 +7,6 @@
 //! This module provides a Cerberus command allowing the versions of various
 //! on-device firmware to be queried.
 
-use core::convert::TryInto as _;
-
 use crate::io::Read;
 use crate::io::Write;
 use crate::mem::Arena;
@@ -100,6 +98,8 @@ make_fuzz_safe! {
 fn deserialize_u8x32<'de: 'a, 'a, D: Deserializer<'de>>(
     d: D,
 ) -> Result<&'a [u8; 32], D::Error> {
+    use core::convert::TryInto as _;
+
     let slice: &'a [u8] = Deserialize::deserialize(d)?;
     slice.try_into().map_err(|_| {
         <D::Error as serde::de::Error>::invalid_length(slice.len(), &"32")


### PR DESCRIPTION
This PR is the result of a lot of pain and suffering on my part trying to make the existing Arena and Flash APIs do the right thing for parsing the PFM. I discovered a few things:

- Coupling the lifetimes of allocations in RAM and a Flash object too closely results in some very difficult to resolve lifetime constraints.
- There's no good way for parsing "packed C structs" out of Flash, which is something Cerberus, as a protocol, expects implementors to do.
- The adapters in flash.rs were mostly unhelpful in this regard, since you really want to bind a Flash to a lifetime by using `&'flash Flash`.
- Region/Ptr feel too boilerplatey and hard to use.

The result is this PR, which contains a number of interrelated changes to how Arenas and Flashes interact. The most important once is the elimination of FlashZero, which is replaced with `Flash::direct_read`. This function allows the user to request a zero-copy read, providing their own arena for the allocation if the request can't be fulfilled.