### PR TITLE
net: Add a DevicePort implementation

### DIFF
--- a/src/net.rs
+++ b/src/net.rs
@@ -451,7 +451,7 @@ impl<'buf> DevicePort for InMemDevice<'buf> {
         self.0.tx_header.set(Some(header));
         self.0.tx.copy_from_slice(msg);
 
-        self.0.finished.set(false);
+        self.0.finished.set(true);
 
         Ok(())
     }

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -206,6 +206,21 @@ impl CommandType {
     }
 }
 
+impl From<u8> for CommandType {
+    fn from(num: u8) -> CommandType {
+        match num {
+            0x01 => CommandType::FirmwareVersion,
+            0x02 => CommandType::DeviceCapabilities,
+            0x03 => CommandType::DeviceId,
+            0x04 => CommandType::DeviceInfo,
+            0x87 => CommandType::ResetCounter,
+            0xa0 => CommandType::DeviceUptime,
+            0xa1 => CommandType::RequestCounter,
+            _ => CommandType::Error,
+        }
+    }
+}
+
 /// A parsed `manticore` header.
 ///
 /// This struct represents all of the meaningful fields from a `manticore`

--- a/src/server/handler.rs
+++ b/src/server/handler.rs
@@ -250,10 +250,10 @@ pub trait HandlerMethods<'req, 'srv, Server: 'srv>:
     fn run<A: Arena>(
         self,
         server: Server,
-        port: &mut dyn net::HostPort,
+        host_port: &mut dyn net::HostPort,
         arena: &'req A,
     ) -> Result<(), Error> {
-        let request = port.receive()?;
+        let request = host_port.receive()?;
         let header = request.header()?;
         if !header.is_request {
             return Err(FromWireError::OutOfRange.into());

--- a/src/server/pa_rot.rs
+++ b/src/server/pa_rot.rs
@@ -73,7 +73,7 @@ where
     #[cfg_attr(test, inline(never))]
     pub fn process_request<'req>(
         &mut self,
-        port: &mut dyn net::HostPort,
+        host_port: &mut dyn net::HostPort,
         arena: &'req impl Arena,
     ) -> Result<(), Error> {
         let result = Handler::<&mut Self>::new()
@@ -166,7 +166,7 @@ where
                     err_count: zelf.err_count,
                 })
             })
-            .run(self, port, arena);
+            .run(self, host_port, arena);
 
         match result {
             Ok(_) => self.ok_count += 1,
@@ -225,8 +225,8 @@ mod test {
             .expect("failed to write request");
         let request_bytes = cursor.take_consumed_bytes();
 
-        let mut port = net::InMemHost::new(port_scratch);
-        port.request(
+        let mut host_port = net::InMemHost::new(port_scratch);
+        host_port.request(
             Header {
                 is_request: true,
                 command: <C::Req as protocol::Request<'a>>::TYPE,
@@ -234,9 +234,9 @@ mod test {
             request_bytes,
         );
 
-        server.process_request(&mut port, arena)?;
+        server.process_request(&mut host_port, arena)?;
 
-        let (header, mut resp) = port.response().unwrap();
+        let (header, mut resp) = host_port.response().unwrap();
         assert!(!header.is_request);
 
         let resp_val = FromWire::from_wire(&mut resp, arena)


### PR DESCRIPTION
This is a WIP attempt at adding a `DevicePort` implementation to Manticore.

This implementation varies greatly from the current `HostPort` implementation, which is why I'm sending a draft PR to see what others think.

The current `HostPort` implementation seems a little complex and I don't think it will integrate well into libtock-rs and the Tock runtime. For example the `HostPort` `receive`() function is blocking, while libtock-rs is non-blocking.

The `DevicePort` implementation is more geared towards integration with libtock-rs and the Tock ecosystem. I wanted to get feedback on the idea before I spend too much time writing documentation, tests and functionality.