### PR TITLE
[manifest] Improve the quality of errors emitted by the `manifest` module.

### DIFF
--- a/src/hardware/flash.rs
+++ b/src/hardware/flash.rs
@@ -553,6 +553,18 @@ impl Region {
         Self::new(0, mem::size_of::<T>() as u32)
     }
 
+    /// Returns a `Region` with the given start and limit.
+    ///
+    /// The length is computed as `limit - start + 1`. Any overflow in
+    /// this operation will cause `None` to be returned.
+    ///
+    /// Note that the due to overflow restrictions, the region starting at
+    /// `0x0000_0000` and ending at `0xffff_ffff` cannot be represented.
+    pub fn from_start_and_limit(start: u32, limit: u32) -> Option<Self> {
+        let len = limit.checked_sub(start)?.checked_add(1)?;
+        Some(Self::new(start, len))
+    }
+
     /// Returns a `Region` big enough to hold a `[T]` with the given number of
     /// elements.
     ///
@@ -564,6 +576,18 @@ impl Region {
     /// Returns the end address of `self`, pointing one past the end of it.
     pub fn end(self) -> u32 {
         self.offset.saturating_add(self.len)
+    }
+
+    /// Represents `self` as a start and a limit: an inclusive range of
+    /// addresses.
+    ///
+    /// Returns `None` if `len == 0`, or if any overflow occurs due to the
+    /// length being too large.
+    pub fn start_and_limit(self) -> Option<(u32, u32)> {
+        Some((
+            self.offset,
+            self.offset.checked_add(self.len)?.checked_sub(1)?,
+        ))
     }
 
     /// Returns a new `Region` that comes immediately after `self`, with the

--- a/src/manifest/mod.rs
+++ b/src/manifest/mod.rs
@@ -154,6 +154,13 @@ pub enum Error {
         toc_index: usize,
     },
 
+    /// Indicates that parsing of a particular element failed because it was
+    /// below the minimum length.
+    TooShort {
+        /// The index of the bad entry.
+        toc_index: usize,
+    },
+
     /// Indicates that some assumption about a manifest's alignment (internal
     /// or overall) was violated.
     Unaligned,
@@ -161,6 +168,10 @@ pub enum Error {
     /// Indicates that a manifest contained a signature type not supported by
     /// the hash engine being used.
     UnsupportedHashType(HashType),
+
+    /// Indicates that the signature length is incompatible with either the
+    /// given manifest length or the signature algorithm.
+    BadSignatureLen,
 
     /// Indicates that a signature operation failed for some reason.
     SignatureFailure,

--- a/src/manifest/mod.rs
+++ b/src/manifest/mod.rs
@@ -114,17 +114,54 @@ pub enum Error {
     ///
     /// [`io`]: ../io/index.html
     Io(io::Error),
+
     /// Indicates that an error occured in a [`flash`] type.
     ///
     /// [`flash`]: ../hardware/flash/html
     Flash(flash::Error),
+
     /// Indicates that an arena ran out of memory.
     OutOfMemory,
+
     /// Indicates that a value was out of its expected range.
     OutOfRange,
+
+    /// Indicates that a manifest's magic value did not match the
+    /// expected one for this manifest type.
+    ///
+    /// Contains the bad value found.
+    BadMagic(u16),
+
+    /// Indicates that the overall TOC hash did not match the actual value.
+    BadTocHash,
+
+    /// Indicates that a TOC entry in the manifest had an invalid parent.
+    BadParent {
+        /// The index of the bad entry.
+        toc_index: usize,
+    },
+
+    /// Indicates that a TOC entry in the manifest had an out-of-range
+    /// hash index.
+    BadHashIndex {
+        /// The index of the bad entry.
+        toc_index: usize,
+    },
+
+    /// Indicates that a TOC entry's hash did not match the actual value.
+    BadElementHash {
+        /// The index of the bad entry.
+        toc_index: usize,
+    },
+
     /// Indicates that some assumption about a manifest's alignment (internal
     /// or overall) was violated.
     Unaligned,
+
+    /// Indicates that a manifest contained a signature type not supported by
+    /// the hash engine being used.
+    UnsupportedHashType(HashType),
+
     /// Indicates that a signature operation failed for some reason.
     SignatureFailure,
 }

--- a/src/manifest/mod.rs
+++ b/src/manifest/mod.rs
@@ -182,6 +182,9 @@ pub enum Error {
     /// given manifest length or the signature algorithm.
     BadSignatureLen,
 
+    /// Indicates that an error occured inside of a hashing engine.
+    HashingError(sha256::Error),
+
     /// Indicates that a signature operation failed for some reason.
     SignatureFailure,
 }
@@ -211,8 +214,8 @@ impl<E> From<rsa::Error<E>> for Error {
 }
 
 impl<E> From<sha256::Error<E>> for Error {
-    fn from(_: sha256::Error<E>) -> Self {
-        Self::SignatureFailure
+    fn from(e: sha256::Error<E>) -> Self {
+        Self::HashingError(e.erased())
     }
 }
 

--- a/src/manifest/mod.rs
+++ b/src/manifest/mod.rs
@@ -161,6 +161,15 @@ pub enum Error {
         toc_index: usize,
     },
 
+    /// Indicates a bad range was found while parsing a particular element.
+    ///
+    /// This indicates that the given range, given as a start and an end, would
+    /// have had negative length.
+    BadRange {
+        /// The index of the bad entry.
+        toc_index: usize,
+    },
+
     /// Indicates that some assumption about a manifest's alignment (internal
     /// or overall) was violated.
     Unaligned,

--- a/src/manifest/owned/pfm.rs
+++ b/src/manifest/owned/pfm.rs
@@ -206,8 +206,9 @@ impl owned::Element for Element {
                     header[0] = rw.flags;
                     bytes.extend_from_slice(&header);
 
-                    bytes.extend_from_slice(&rw.region.offset.to_le_bytes());
-                    let end = rw.region.offset + rw.region.len;
+                    let (start, end) =
+                        rw.region.start_and_limit().ok_or(Error::OutOfRange)?;
+                    bytes.extend_from_slice(&start.to_le_bytes());
                     bytes.extend_from_slice(&end.to_le_bytes());
                 }
 
@@ -225,8 +226,10 @@ impl owned::Element for Element {
                     ]);
                     bytes.extend_from_slice(&image.hash);
                     for region in &image.regions {
-                        bytes.extend_from_slice(&region.offset.to_le_bytes());
-                        let end = region.offset + region.len;
+                        let (start, end) = region
+                            .start_and_limit()
+                            .ok_or(Error::OutOfRange)?;
+                        bytes.extend_from_slice(&start.to_le_bytes());
                         bytes.extend_from_slice(&end.to_le_bytes());
                     }
                 }


### PR DESCRIPTION
Unfortunately, this does not include `thiserror` support, because that crate requires `std`.