### PR TITLE
[manifest] Add an intermediate type to represent all PFMs as a whole

### DIFF
--- a/src/manifest/container.rs
+++ b/src/manifest/container.rs
@@ -583,15 +583,14 @@ pub(crate) mod test {
         let bytes = Ram(pfm.sign(0x0, &sha, &mut signer).unwrap());
         type Flash = Ram<Vec<u8>>;
 
-        let container: Container<'_, Pfm<'_, Flash>, Flash> =
-            Container::parse_and_verify(
-                &bytes,
-                &sha,
-                &mut rsa,
-                &OutOfMemory,
-                &OutOfMemory,
-            )
-            .unwrap();
+        let container: Container<'_, Pfm, Flash> = Container::parse_and_verify(
+            &bytes,
+            &sha,
+            &mut rsa,
+            &OutOfMemory,
+            &OutOfMemory,
+        )
+        .unwrap();
         assert_eq!(container.metadata().version_id, 42);
 
         let toc = container.toc();
@@ -614,15 +613,14 @@ pub(crate) mod test {
         let bytes = Ram(pfm.sign(0x0, &sha, &mut signer).unwrap());
         type Flash = Ram<Vec<u8>>;
 
-        let container: Container<'_, Pfm<'_, Flash>, Flash> =
-            Container::parse_and_verify(
-                &bytes,
-                &sha,
-                &mut rsa,
-                &OutOfMemory,
-                &OutOfMemory,
-            )
-            .unwrap();
+        let container: Container<'_, Pfm, Flash> = Container::parse_and_verify(
+            &bytes,
+            &sha,
+            &mut rsa,
+            &OutOfMemory,
+            &OutOfMemory,
+        )
+        .unwrap();
 
         let toc = container.toc();
         assert_eq!(toc.len(), 1);
@@ -658,15 +656,14 @@ pub(crate) mod test {
         let bytes = Ram(pfm.sign(0x0, &sha, &mut signer).unwrap());
         type Flash = Ram<Vec<u8>>;
 
-        let container: Container<'_, Pfm<'_, Flash>, Flash> =
-            Container::parse_and_verify(
-                &bytes,
-                &sha,
-                &mut rsa,
-                &OutOfMemory,
-                &OutOfMemory,
-            )
-            .unwrap();
+        let container: Container<'_, Pfm, Flash> = Container::parse_and_verify(
+            &bytes,
+            &sha,
+            &mut rsa,
+            &OutOfMemory,
+            &OutOfMemory,
+        )
+        .unwrap();
 
         let toc = container.toc();
         assert_eq!(toc.len(), 2);

--- a/src/manifest/owned/mod.rs
+++ b/src/manifest/owned/mod.rs
@@ -71,12 +71,17 @@ pub trait Element: Sized {
 #[doc(hidden)]
 pub trait FromUnowned<'f, F: Flash>: Element {
     /// The "unowned" type.
-    type Unowned: Manifest;
+    type Manifest: Manifest;
 
     /// Walks a parsed container of this manifest type, building a tree of
     /// elements along the way.
     fn from_container(
-        container: manifest::Container<'f, Self::Unowned, F, provenance::Adhoc>,
+        container: manifest::Container<
+            'f,
+            Self::Manifest,
+            F,
+            provenance::Adhoc,
+        >,
     ) -> Result<Vec<Node<Self>>, Error>;
 }
 
@@ -218,11 +223,12 @@ impl<E: Element> Container<E> {
         };
 
         let ram = Ram(bytes);
-        let container =
-            manifest::Container::<'_, E::Unowned, _, provenance::Adhoc>::parse(
-                &ram,
-                &OutOfMemory,
-            )?;
+        let container = manifest::Container::<
+            '_,
+            E::Manifest,
+            _,
+            provenance::Adhoc,
+        >::parse(&ram, &OutOfMemory)?;
         // TODO(#58): Right now we ignore a bunch of "implied" fields in the
         // manifest, but we may want to either reject failures, use them,
         // or simply report them.

--- a/src/manifest/owned/pfm.rs
+++ b/src/manifest/owned/pfm.rs
@@ -259,14 +259,19 @@ impl owned::Element for Element {
 }
 
 impl<'f, F: 'f + Flash> owned::FromUnowned<'f, F> for Element {
-    type Unowned = manifest::pfm::Pfm<'f, F, provenance::Adhoc>;
+    type Manifest = manifest::pfm::Pfm;
 
     fn from_container(
-        container: manifest::Container<'f, Self::Unowned, F, provenance::Adhoc>,
+        container: manifest::Container<
+            'f,
+            Self::Manifest,
+            F,
+            provenance::Adhoc,
+        >,
     ) -> Result<Vec<owned::Node<Self>>, Error> {
         let mut arena = vec![0; 2048];
         let mut arena = BumpArena::new(&mut arena);
-        let pfm = manifest::pfm::Pfm::new(container);
+        let pfm = manifest::pfm::ParsedPfm::new(container);
         let sha = RingSha::new();
         let mut nodes = Vec::new();
 


### PR DESCRIPTION
This change has two benefits:
- It removes proliferation of repeated type parameters all over the place,
  since we can now write `Pfm` instead of `ParsedPfm<'all, 'kinds, Of,
  Stuff>`.
- It makes it possible to have code generic over all Pfms that can
  specialize a ParsedPfm for different Flash types and whatnot with
  minimal threading of type parameters around.

This will be particularly useful when we add the manifest manager, which needs to be able to deal with manifests of fixed type but different underlying storage.