### PR TITLE
server: Initial support for the AC-RoT

### DIFF
--- a/src/server/ac_rot.rs
+++ b/src/server/ac_rot.rs
@@ -1,0 +1,171 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+//! A `manticore` "server" for a AC-RoT.
+//!
+//! This module provides structures for serving responses to a PA-RoT making
+//! requests to an AC-RoT.
+
+use crate::crypto::rsa;
+use crate::hardware;
+use crate::mem::Arena;
+use crate::net;
+use crate::server::options::Options;
+use crate::server::response::Respond;
+use crate::server::rot::Rot;
+use crate::server::Error;
+
+/// A AC-RoT, or "Active Component's Root of Trust", server.
+///
+/// This type implements the request -> response "business logic" of the
+/// PA-Rot <-> AC-RoT interaction.
+pub struct AcRot<'a, Identity, Reset, Rsa> {
+    rot: Rot<'a, Identity, Reset, Rsa>,
+}
+
+impl<'a, Identity, Reset, Rsa> AcRot<'a, Identity, Reset, Rsa>
+where
+    Identity: hardware::Identity,
+    Reset: hardware::Reset,
+    Rsa: rsa::Builder,
+{
+    /// Create a new `AcRot` with the given `Options`.
+    pub fn new(opts: Options<'a, Identity, Reset, Rsa>) -> Self {
+        Self {
+            rot: Rot::new(opts),
+        }
+    }
+}
+
+impl<'a, Identity, Reset, Rsa> Respond for AcRot<'a, Identity, Reset, Rsa>
+where
+    Identity: hardware::Identity,
+    Reset: hardware::Reset,
+    Rsa: rsa::Builder,
+{
+    fn process_request<'req>(
+        &mut self,
+        host_port: &mut dyn net::HostPort,
+        arena: &'req impl Arena,
+    ) -> Result<(), Error> {
+        self.rot.process_request(host_port, arena)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::crypto::ring;
+    use crate::hardware::fake;
+    use crate::hardware::Identity as _;
+    use crate::io::Cursor;
+    use crate::mem::BumpArena;
+    use crate::protocol;
+    use crate::protocol::capabilities::*;
+    use crate::protocol::device_id;
+    use crate::protocol::wire::FromWire;
+    use crate::protocol::wire::ToWire;
+    use crate::protocol::Header;
+    use core::time::Duration;
+
+    const NETWORKING: Networking = Networking {
+        max_message_size: 1024,
+        max_packet_size: 256,
+        mode: RotMode::Active,
+        roles: BusRole::TARGET,
+    };
+
+    const TIMEOUTS: Timeouts = Timeouts {
+        regular: Duration::from_millis(30),
+        crypto: Duration::from_millis(200),
+    };
+
+    const DEVICE_ID: device_id::DeviceIdentifier =
+        device_id::DeviceIdentifier {
+            vendor_id: 1,
+            device_id: 2,
+            subsys_vendor_id: 3,
+            subsys_id: 4,
+        };
+
+    fn simulate_request<'a, C: protocol::Command<'a>, A: Arena>(
+        scratch_space: &'a mut [u8],
+        arena: &'a mut A,
+        server: &mut AcRot<fake::Identity, fake::Reset, ring::rsa::Builder>,
+        request: C::Req,
+    ) -> Result<C::Resp, Error> {
+        let len = scratch_space.len();
+        let (req_scratch, port_scratch) = scratch_space.split_at_mut(len / 2);
+        let mut cursor = Cursor::new(req_scratch);
+        request
+            .to_wire(&mut cursor)
+            .expect("failed to write request");
+        let request_bytes = cursor.take_consumed_bytes();
+
+        let mut port = net::InMemHost::new(port_scratch);
+        port.request(
+            Header {
+                is_request: true,
+                command: <C::Req as protocol::Request<'a>>::TYPE,
+            },
+            request_bytes,
+        );
+
+        server.process_request(&mut port, arena)?;
+
+        let (header, mut resp) = port.response().unwrap();
+        assert!(!header.is_request);
+
+        let resp_val = FromWire::from_wire(&mut resp, arena)
+            .expect("failed to read response");
+        assert_eq!(resp.len(), 0);
+        Ok(resp_val)
+    }
+
+    #[test]
+    fn sanity() {
+        let identity = fake::Identity::new(
+            b"test version",
+            &[(1, b"vendor fw 1"), (3, b"vendor fw 3")],
+            b"random bits",
+        );
+        let reset = fake::Reset::new(0, Duration::from_millis(1));
+        let rsa = ring::rsa::Builder::new();
+        let mut server = AcRot::new(Options {
+            identity: &identity,
+            reset: &reset,
+            rsa: &rsa,
+            device_id: DEVICE_ID,
+            networking: NETWORKING,
+            timeouts: TIMEOUTS,
+        });
+
+        let mut scratch = [0; 1024];
+        let mut arena = [0; 64];
+        let mut arena = BumpArena::new(&mut arena);
+
+        let req =
+            protocol::firmware_version::FirmwareVersionRequest { index: 0 };
+        let resp = simulate_request::<protocol::FirmwareVersion, _>(
+            &mut scratch,
+            &mut arena,
+            &mut server,
+            req,
+        )
+        .expect("got error from server");
+        assert_eq!(resp.version, identity.firmware_version());
+
+        arena.reset();
+
+        let req = protocol::device_id::DeviceIdRequest;
+        let resp = simulate_request::<protocol::DeviceId, _>(
+            &mut scratch,
+            &mut arena,
+            &mut server,
+            req,
+        )
+        .expect("got error from server");
+        assert_eq!(resp.id, DEVICE_ID);
+    }
+}

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -12,6 +12,7 @@
 mod handler;
 pub use handler::Error;
 
+pub mod ac_rot;
 pub mod options;
 pub mod pa_rot;
 pub mod response;

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -12,4 +12,5 @@
 mod handler;
 pub use handler::Error;
 
+pub mod options;
 pub mod pa_rot;

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -14,3 +14,4 @@ pub use handler::Error;
 
 pub mod options;
 pub mod pa_rot;
+mod rot;

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -14,4 +14,5 @@ pub use handler::Error;
 
 pub mod options;
 pub mod pa_rot;
+pub mod response;
 mod rot;

--- a/src/server/options.rs
+++ b/src/server/options.rs
@@ -1,0 +1,30 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Options for a `manticore` "server" and "client" for a RoT.
+
+use crate::protocol::capabilities;
+use crate::protocol::device_id;
+#[cfg(doc)]
+use crate::server::pa_rot::PaRot;
+
+/// Options struct for initialising a [`PaRot`].
+pub struct Options<'a, Identity, Reset, Rsa> {
+    /// A handle to the "hardware identity" of the device.
+    pub identity: &'a Identity,
+    /// A handle for looking up reset-related information for the current
+    /// device.
+    pub reset: &'a Reset,
+
+    /// A handle to an RSA engine builder.
+    pub rsa: &'a Rsa,
+
+    /// This device's silicon identifier.
+    pub device_id: device_id::DeviceIdentifier,
+    /// Integration-provided description of the device's networking
+    /// capabilities.
+    pub networking: capabilities::Networking,
+    /// Integration-provided "acceptable timeout" lengths.
+    pub timeouts: capabilities::Timeouts,
+}

--- a/src/server/options.rs
+++ b/src/server/options.rs
@@ -7,9 +7,12 @@
 use crate::protocol::capabilities;
 use crate::protocol::device_id;
 #[cfg(doc)]
+use crate::server::ac_rot::AcRot;
+#[cfg(doc)]
 use crate::server::pa_rot::PaRot;
 
-/// Options struct for initialising a [`PaRot`].
+/// Options struct for initialising a [`PaRot`]
+/// and [`AcRot`].
 pub struct Options<'a, Identity, Reset, Rsa> {
     /// A handle to the "hardware identity" of the device.
     pub identity: &'a Identity,

--- a/src/server/pa_rot.rs
+++ b/src/server/pa_rot.rs
@@ -12,31 +12,10 @@ use crate::hardware;
 use crate::mem::Arena;
 use crate::net;
 use crate::protocol;
-use crate::protocol::capabilities;
-use crate::protocol::device_id;
+use crate::server::options::Options;
 use crate::server::Error;
 
 use crate::server::handler::prelude::*;
-
-/// Options struct for initializing a [`PaRot`].
-pub struct Options<'a, Identity, Reset, Rsa> {
-    /// A handle to the "hardware identity" of the device.
-    pub identity: &'a Identity,
-    /// A handle for looking up reset-related information for the current
-    /// device.
-    pub reset: &'a Reset,
-
-    /// A handle to an RSA engine builder.
-    pub rsa: &'a Rsa,
-
-    /// This device's silicon identifier.
-    pub device_id: device_id::DeviceIdentifier,
-    /// Integration-provided description of the device's networking
-    /// capabilities.
-    pub networking: capabilities::Networking,
-    /// Integration-provided "acceptable timeout" lengths.
-    pub timeouts: capabilities::Timeouts,
-}
 
 /// A PA-RoT, or "Platform Root of Trust", server.
 ///
@@ -203,6 +182,7 @@ mod test {
     use crate::mem::BumpArena;
     use crate::net::DevicePort;
     use crate::protocol::capabilities::*;
+    use crate::protocol::device_id;
     use crate::protocol::wire::FromWire;
     use crate::protocol::wire::ToWire;
     use crate::protocol::Header;

--- a/src/server/pa_rot.rs
+++ b/src/server/pa_rot.rs
@@ -12,6 +12,7 @@ use crate::hardware;
 use crate::mem::Arena;
 use crate::net;
 use crate::server::options::Options;
+use crate::server::response::Respond;
 use crate::server::rot::Rot;
 use crate::server::Error;
 
@@ -36,12 +37,15 @@ where
             rot: Rot::new(opts),
         }
     }
+}
 
-    /// Process a single incoming request.
-    ///
-    /// The request message will be read from `req`, while the response
-    /// message will be written to `resp`.
-    pub fn process_request<'req>(
+impl<'a, Identity, Reset, Rsa> Respond for PaRot<'a, Identity, Reset, Rsa>
+where
+    Identity: hardware::Identity,
+    Reset: hardware::Reset,
+    Rsa: rsa::Builder,
+{
+    fn process_request<'req>(
         &mut self,
         host_port: &mut dyn net::HostPort,
         arena: &'req impl Arena,

--- a/src/server/response.rs
+++ b/src/server/response.rs
@@ -1,0 +1,22 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+//! The ability for an RoT to respond to requests.
+
+use crate::mem::Arena;
+use crate::net;
+use crate::server::Error;
+
+/// The ability for an RoT to respond to requests.
+pub trait Respond {
+    /// Process a single incoming request.
+    ///
+    /// The request message will be read from `req`, while the response
+    /// message will be written to `resp`.
+    fn process_request<'req>(
+        &mut self,
+        host_port: &mut dyn net::HostPort,
+        arena: &'req impl Arena,
+    ) -> Result<(), Error>;
+}

--- a/src/server/rot.rs
+++ b/src/server/rot.rs
@@ -13,6 +13,7 @@ use crate::mem::Arena;
 use crate::net;
 use crate::protocol;
 use crate::server::options::Options;
+use crate::server::response::Respond;
 use crate::server::Error;
 
 use crate::server::handler::prelude::*;
@@ -45,12 +46,15 @@ where
             err_count: 0,
         }
     }
+}
 
-    /// Process a single incoming request.
-    ///
-    /// The request message will be read from `req`, while the response
-    /// message will be written to `resp`.
-    pub fn process_request<'req>(
+impl<'a, Identity, Reset, Rsa> Respond for Rot<'a, Identity, Reset, Rsa>
+where
+    Identity: hardware::Identity,
+    Reset: hardware::Reset,
+    Rsa: rsa::Builder,
+{
+    fn process_request<'req>(
         &mut self,
         host_port: &mut dyn net::HostPort,
         arena: &'req impl Arena,

--- a/src/server/rot.rs
+++ b/src/server/rot.rs
@@ -1,0 +1,160 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+//! A `manticore` "server" AC and PR RoTs.
+//!
+//! This module provides structures for serving responses to a host making
+//! requests to a PA-RoT and AC-RoT.
+
+use crate::crypto::rsa;
+use crate::hardware;
+use crate::mem::Arena;
+use crate::net;
+use crate::protocol;
+use crate::server::options::Options;
+use crate::server::Error;
+
+use crate::server::handler::prelude::*;
+
+/// A RoT, or "Root of Trust", server.
+///
+/// This type implements the request -> response "business logic" of the
+/// host <-> PA-RoT interaction or the PA-RoT <-> AC-RoT. That is, it accepts
+/// input and output buffers, and from those, parses incoming requests and
+/// processes them into responses.
+///
+/// This is a generic RoT type that can be used as either a AC-RoT or a PA-RoT.
+pub(crate) struct Rot<'a, Identity, Reset, Rsa> {
+    opts: Options<'a, Identity, Reset, Rsa>,
+    ok_count: u16,
+    err_count: u16,
+}
+
+impl<'a, Identity, Reset, Rsa> Rot<'a, Identity, Reset, Rsa>
+where
+    Identity: hardware::Identity,
+    Reset: hardware::Reset,
+    Rsa: rsa::Builder,
+{
+    /// Create a new `Rot` with the given `Options`.
+    pub fn new(opts: Options<'a, Identity, Reset, Rsa>) -> Self {
+        Self {
+            opts,
+            ok_count: 0,
+            err_count: 0,
+        }
+    }
+
+    /// Process a single incoming request.
+    ///
+    /// The request message will be read from `req`, while the response
+    /// message will be written to `resp`.
+    pub fn process_request<'req>(
+        &mut self,
+        host_port: &mut dyn net::HostPort,
+        arena: &'req impl Arena,
+    ) -> Result<(), Error> {
+        let result = Handler::<&mut Self>::new()
+            .handle::<protocol::FirmwareVersion, _>(|zelf, req| {
+                use protocol::firmware_version::FirmwareVersionResponse;
+                if req.index == 0 {
+                    return Ok(FirmwareVersionResponse {
+                        version: zelf.opts.identity.firmware_version(),
+                    });
+                }
+
+                match zelf.opts.identity.vendor_firmware_version(req.index) {
+                    Some(version) => Ok(FirmwareVersionResponse { version }),
+                    None => Err(protocol::Error {
+                        code: protocol::ErrorCode::Unspecified,
+                        data: [0; 4],
+                    }),
+                }
+            })
+            .handle::<protocol::DeviceCapabilities, _>(|zelf, req| {
+                use protocol::capabilities::*;
+                // For now, we drop the client's capabilities on the ground.
+                // Eventually, these should be used for negotiation of crypto
+                // use.
+                let _ = req.capabilities;
+
+                let rsa_strength = RsaKeyStrength::from_builder(zelf.opts.rsa);
+
+                let capabilities = Capabilities {
+                    networking: zelf.opts.networking,
+                    security: Security::empty(),
+
+                    has_pfm_support: false,
+                    has_policy_support: false,
+                    has_firmware_protection: false,
+
+                    has_ecdsa: false,
+                    has_ecc: false,
+                    has_rsa: !rsa_strength.is_empty(),
+                    has_aes: false,
+
+                    ecc_strength: EccKeyStrength::empty(),
+                    rsa_strength,
+                    aes_strength: AesKeyStrength::empty(),
+                };
+
+                Ok(protocol::capabilities::DeviceCapabilitiesResponse {
+                    capabilities,
+                    timeouts: zelf.opts.timeouts,
+                })
+            })
+            .handle::<protocol::DeviceId, _>(|zelf, _| {
+                Ok(protocol::device_id::DeviceIdResponse {
+                    id: zelf.opts.device_id,
+                })
+            })
+            .handle::<protocol::DeviceInfo, _>(|zelf, _| {
+                Ok(protocol::device_info::DeviceInfoResponse {
+                    info: zelf.opts.identity.unique_device_identity(),
+                })
+            })
+            .handle::<protocol::ResetCounter, _>(|zelf, req| {
+                use protocol::reset_counter::*;
+                // NOTE: Currently, we only handle "local resets" for port 0,
+                // the "self" port.
+                if req.reset_type != ResetType::Local || req.port_id != 0 {
+                    return Err(protocol::Error {
+                        code: protocol::ErrorCode::Unspecified,
+                        data: [0; 4],
+                    });
+                }
+
+                Ok(ResetCounterResponse {
+                    count: zelf.opts.reset.resets_since_power_on() as u16,
+                })
+            })
+            .handle::<protocol::DeviceUptime, _>(|zelf, req| {
+                use protocol::device_uptime::*;
+                // NOTE: CUrrently, we only handle port 0, the "self" port.
+                if req.port_id != 0 {
+                    return Err(protocol::Error {
+                        code: protocol::ErrorCode::Unspecified,
+                        data: [0; 4],
+                    });
+                }
+                Ok(DeviceUptimeResponse {
+                    uptime: zelf.opts.reset.uptime(),
+                })
+            })
+            .handle::<protocol::RequestCounter, _>(|zelf, _| {
+                use protocol::request_counter::*;
+                Ok(RequestCounterResponse {
+                    ok_count: zelf.ok_count,
+                    err_count: zelf.err_count,
+                })
+            })
+            .run(self, host_port, arena);
+
+        match result {
+            Ok(_) => self.ok_count += 1,
+            Err(_) => self.err_count += 1,
+        }
+        result
+    }
+}


### PR DESCRIPTION
This PR focuses on initial support for the AC-RoT.

In terms of responding to requests the AC-RoT is pretty much identical to the PA-RoT responding to requests. To allow us to reuse the code this PR splits out the `process_request()` function into a trait and then has a generic `RoT` struct that is used by both AC-RoT and PA-RoT. As Rust doesn't have inheritance this ends up being the simplest way that I could think of to handle this.

This way in the future the AC-RoT and PA-RoT can have specific functions added (for example `send_request()`) and also add new traits to extend shared functionality.