### PR TITLE
Add the beginnings of proper end-to-end testing for Manticore

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -40,3 +40,6 @@ jobs:
 
     - name: Run tests
       run: cargo test --verbose
+
+    - name: Run e2e tests
+      run: cargo test -v -p manticore-e2e -- run-tests

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ repository = "https://github.com/lowRISC/manticore"
 description = "A WIP implementation of the Cerberus attestation protocol"
 
 [workspace]
-members = [".", "tool"]
+members = [".", "e2e", "tool"]
 
 [dependencies]
 arrayvec = { version = "0.5.1", default_features = false }

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -1,0 +1,18 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+[package]
+name = "manticore-e2e"
+version = "0.0.0"
+edition = "2018"
+
+authors = ["lowRISC Contributors"]
+license = "Apache-2.0"
+homepage = "https://opentitan.org/"
+repository = "https://github.com/lowRISC/manticore"
+description = "End-to-end tests for Manticore"
+
+[dependencies]
+manticore = { path = ".." }
+structopt = "0.3.16"

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -16,3 +16,4 @@ description = "End-to-end tests for Manticore"
 [dependencies]
 manticore = { path = ".." }
 structopt = "0.3.16"
+serde_json = "1.0"

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -15,5 +15,8 @@ description = "End-to-end tests for Manticore"
 
 [dependencies]
 manticore = { path = ".." }
-structopt = "0.3.16"
+
+env_logger = "0.8"
+log = "0.4"
 serde_json = "1.0"
+structopt = "0.3.16"

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,0 +1,21 @@
+# End-to-end tests for Manticore.
+
+This crate operates as follows. When run as `./e2e run-tests`, it will
+re-exec a copy of the process via `./e2e serve`. This new process is a
+"virtual RoT", which is connected back to the parent over a TCP "bus".
+The parent can then actuate the virtual RoT as a sort of black box.
+
+This crate serves two major purposes:
+1. To provide an easy way to black-box test Manticore; in the future, we'd
+   like to be able to make it possible to test other implementations, such
+   as Azure's Cerberus implementation.
+2. To provide an example *integration* for platform integrators to
+   understand how to build a Cerberus-compliant device using Manticore's
+   toolkit.
+
+To actually run these tests against manticore, run do
+```
+cargo run -p manticore-e2e -- run-tests
+```
+If a port allocation error occurs, the `--port` flag may be used to specify one
+explicitly.

--- a/e2e/src/main.rs
+++ b/e2e/src/main.rs
@@ -1,0 +1,7 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+fn main() {
+    println!("Hello, world!");
+}

--- a/e2e/src/main.rs
+++ b/e2e/src/main.rs
@@ -2,6 +2,58 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#![deny(warnings)]
+#![deny(unused)]
+#![deny(unsafe_code)]
+//#![deny(missing_docs)]
+
+use structopt::StructOpt;
+
+use manticore::mem::BumpArena;
+use manticore::protocol::firmware_version::FirmwareVersion;
+use manticore::protocol::firmware_version::FirmwareVersionRequest;
+
+pub mod pa_rot;
+pub mod tcp;
+
+#[derive(Debug, StructOpt)]
+enum Options {
+    RunTests {
+        #[structopt(long, short, default_value = "9999")]
+        port: u16,
+    },
+    Serve(pa_rot::Options),
+}
+
 fn main() {
-    println!("Hello, world!");
+    let _ = Options::from_args();
+    match Options::from_args() {
+        Options::RunTests { port, .. } => {
+            let mut subproc = pa_rot::Options {
+                port,
+                firmware_version: b"my cool e2e test".to_vec(),
+                ..Default::default()
+            }
+            .self_exec();
+
+            let mut arena = [0; 64];
+            let arena = BumpArena::new(&mut arena);
+            let resp = tcp::send_local::<FirmwareVersion, _>(
+                port,
+                FirmwareVersionRequest { index: 0 },
+                &arena,
+            )
+            .unwrap()
+            .unwrap();
+
+            eprintln!(
+                "resp.version: {}",
+                std::str::from_utf8(resp.version).unwrap()
+            );
+            assert!(resp.version.starts_with(b"my cool e2e test"));
+
+            subproc.kill().unwrap();
+        }
+        Options::Serve(opts) => pa_rot::serve(opts),
+    }
 }

--- a/e2e/src/pa_rot.rs
+++ b/e2e/src/pa_rot.rs
@@ -1,0 +1,233 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+//! A `manticore` server that can be spoken to over local TCP.
+
+use std::io::BufRead as _;
+use std::io::BufReader;
+use std::num::ParseIntError;
+use std::process::Child;
+use std::process::Command;
+use std::process::Stdio;
+use std::str;
+use std::time::Duration;
+use std::time::Instant;
+
+use structopt::StructOpt;
+
+use manticore::crypto::ring;
+use manticore::mem::Arena as _;
+use manticore::mem::BumpArena;
+use manticore::protocol::capabilities;
+use manticore::protocol::device_id::DeviceIdentifier;
+use manticore::server::pa_rot::PaRot;
+
+use crate::tcp::TcpHostPort;
+
+// Exists to work around structopt wanting to interpret a
+// Vec field as being "multiple arguments allowed".
+#[doc(hidden)]
+pub type Bytes = Vec<u8>;
+
+mod parse {
+    use super::*;
+
+    pub fn bytes(s: &str) -> Bytes {
+        s.as_bytes().to_vec()
+    }
+
+    pub fn millis(s: &str) -> Result<Duration, ParseIntError> {
+        Ok(Duration::from_millis(s.parse()?))
+    }
+}
+
+#[derive(Debug, StructOpt)]
+pub struct Options {
+    #[structopt(short, long)]
+    pub port: u16,
+    #[structopt(
+        long,
+        default_value = "<version unspecified>",
+        parse(from_str = parse::bytes),
+    )]
+    pub firmware_version: Bytes,
+    #[structopt(
+        long,
+        default_value = "<uid unspecified>",
+        parse(from_str = parse::bytes),
+    )]
+    pub unique_device_identity: Bytes,
+    #[structopt(long, default_value = "0")]
+    pub resets_since_power_on: u32,
+
+    #[structopt(long, default_value = "1024")]
+    pub max_message_size: u16,
+    #[structopt(long, default_value = "256")]
+    pub max_packet_size: u16,
+
+    #[structopt(
+        long,
+        default_value = "30",
+        parse(try_from_str = parse::millis),
+    )]
+    pub regular_timeout: Duration,
+    #[structopt(
+        long,
+        default_value = "200",
+        parse(try_from_str = parse::millis),
+    )]
+    pub crypto_timeout: Duration,
+
+    #[structopt(
+        long,
+        default_value = r#"{"vendor_id":1,"device_id":2,"subsys_vendor_id":3,"subsys_id":4}"#,
+        parse(try_from_str = serde_json::from_str),
+    )]
+    pub device_id: DeviceIdentifier,
+}
+
+impl Default for Options {
+    fn default() -> Self {
+        Self {
+            port: 9999,
+            firmware_version: b"<version unspecified>".to_vec(),
+            unique_device_identity: b"<uid unspecified>".to_vec(),
+            resets_since_power_on: 5,
+            max_message_size: 1024,
+            max_packet_size: 256,
+            regular_timeout: Duration::from_millis(30),
+            crypto_timeout: Duration::from_millis(200),
+            device_id: DeviceIdentifier {
+                vendor_id: 1,
+                device_id: 2,
+                subsys_vendor_id: 3,
+                subsys_id: 4,
+            },
+        }
+    }
+}
+
+impl Options {
+    /// Convert this `Options` into command-line arguments. This is intended
+    /// for simplifying an exec-into-self workflow.
+    pub fn unparse(&self) -> Vec<String> {
+        vec![
+            format!("serve"),
+            format!("--port={}", self.port),
+            // TODO: Come up with a non-panicking option.
+            format!(
+                "--firmware-version={}",
+                str::from_utf8(self.firmware_version.as_ref()).unwrap()
+            ),
+            format!(
+                "--unique-device-identity={}",
+                str::from_utf8(self.unique_device_identity.as_ref()).unwrap()
+            ),
+            format!("--resets-since-power-on={}", self.resets_since_power_on),
+            format!("--max-message-size={}", self.max_message_size),
+            format!("--max-packet-size={}", self.max_packet_size),
+            format!("--regular-timeout={}", self.regular_timeout.as_millis()),
+            format!("--crypto-timeout={}", self.crypto_timeout.as_millis()),
+            format!(
+                "--device-id={}",
+                serde_json::to_string(&self.device_id).unwrap()
+            ),
+        ]
+    }
+
+    /// Spawns a subprocess that serves a PA-RoT describes by this `Options`.
+    pub fn self_exec(&self) -> Child {
+        // Get argv[0]. We assume this is the path to the executable.
+        let exe = std::env::args_os().next().unwrap();
+        let args = self.unparse();
+        let mut child = Command::new(exe)
+            .args(&args)
+            .stdout(Stdio::piped())
+            .spawn()
+            .expect("failed to spawn server subprocess");
+        let mut stdout = BufReader::new(child.stdout.take().unwrap());
+        let mut line = String::new();
+
+        // Wait until the child signals it's ready by writing a line to stdout.
+        stdout.read_line(&mut line).unwrap();
+        print!("{}", line);
+        child
+    }
+}
+
+pub fn serve(opts: Options) -> ! {
+    let networking = capabilities::Networking {
+        max_message_size: opts.max_message_size,
+        max_packet_size: opts.max_packet_size,
+        mode: capabilities::RotMode::Platform,
+        roles: capabilities::BusRole::HOST,
+    };
+
+    let timeouts = capabilities::Timeouts {
+        regular: opts.regular_timeout,
+        crypto: opts.crypto_timeout,
+    };
+
+    struct Id {
+        firmware_version: [u8; 32],
+        unique_device_identity: Bytes,
+    }
+    impl manticore::hardware::Identity for Id {
+        fn firmware_version(&self) -> &[u8; 32] {
+            &self.firmware_version
+        }
+        fn unique_device_identity(&self) -> &[u8] {
+            &self.unique_device_identity[..]
+        }
+    }
+    let mut identity = Id {
+        firmware_version: [0; 32],
+        unique_device_identity: opts.unique_device_identity,
+    };
+    let prefix_len = opts.firmware_version.len().min(32);
+
+    identity.firmware_version[..prefix_len]
+        .copy_from_slice(&opts.firmware_version[..prefix_len]);
+
+    struct Reset {
+        startup_time: Instant,
+        resets_since_power_on: u32,
+    }
+    impl manticore::hardware::Reset for Reset {
+        fn resets_since_power_on(&self) -> u32 {
+            self.resets_since_power_on
+        }
+
+        fn uptime(&self) -> Duration {
+            self.startup_time.elapsed()
+        }
+    }
+    let reset = Reset {
+        startup_time: Instant::now(),
+        resets_since_power_on: opts.resets_since_power_on,
+    };
+
+    let mut ciphers = ring::sig::Ciphers::new();
+
+    let mut server = PaRot::new(manticore::server::pa_rot::Options {
+        identity: &identity,
+        reset: &reset,
+        ciphers: &mut ciphers,
+        device_id: opts.device_id,
+        networking,
+        timeouts,
+    });
+
+    let mut host = TcpHostPort::bind(opts.port).unwrap();
+    println!("listening at localhost:{}", opts.port);
+
+    let mut arena = vec![0; 64];
+    let mut arena = BumpArena::new(&mut arena);
+
+    loop {
+        // TODO: handle this gracefully instead of crashing on a bad packet.
+        server.process_request(&mut host, &arena).unwrap();
+        arena.reset();
+    }
+}

--- a/e2e/src/tcp.rs
+++ b/e2e/src/tcp.rs
@@ -1,0 +1,261 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+//! A TCP-based Manticore `HostPort`.
+//!
+//! This specific binding of Manticore implements the abstract Cerberus header
+//! as a four-bytes, consisting of, in order:
+//! 1. The command type byte.
+//! 2. The request bit; `0` for responses, `1` for requests.
+//! 3. The length of the payload as a little-endian `u16`.
+
+use std::io::Read as _;
+use std::io::Write as _;
+use std::net::TcpListener;
+use std::net::TcpStream;
+
+use manticore::io;
+use manticore::mem::Arena;
+use manticore::net;
+use manticore::net::HostPort;
+use manticore::net::HostRequest;
+use manticore::net::HostResponse;
+use manticore::protocol;
+use manticore::protocol::wire::FromWire;
+use manticore::protocol::wire::ToWire;
+use manticore::protocol::wire::WireEnum;
+use manticore::protocol::Command;
+use manticore::protocol::CommandType;
+use manticore::protocol::Header;
+use manticore::protocol::Request;
+use manticore::protocol::Response;
+use manticore::server;
+
+pub fn send_local<'a, Cmd, A>(
+    port: u16,
+    req: Cmd::Req,
+    arena: &'a A,
+) -> Result<Result<Cmd::Resp, protocol::Error>, server::Error>
+where
+    Cmd: Command<'a>,
+    A: Arena,
+{
+    let mut conn = TcpStream::connect(("127.0.0.1", port))
+        .map_err(|_| net::Error::Io(io::Error::Internal))?;
+    let mut writer = Writer::new(Header {
+        command: <Cmd::Req as Request>::TYPE,
+        is_request: true,
+    });
+    req.to_wire(&mut writer)?;
+    writer.finish(&mut conn)?;
+
+    /// Helper struct for exposing a TCP stream as a Manticore reader.
+    struct Reader<'a>(&'a mut TcpStream, usize);
+    impl io::Read for Reader<'_> {
+        fn read_bytes(&mut self, out: &mut [u8]) -> Result<(), io::Error> {
+            let Reader(stream, len) = self;
+            if *len < out.len() {
+                return Err(io::Error::BufferExhausted);
+            }
+            stream.read_exact(out).map_err(|_| io::Error::Internal)?;
+            *len -= out.len();
+            Ok(())
+        }
+
+        fn remaining_data(&self) -> usize {
+            self.1
+        }
+    }
+    let (header, len) = header_from_wire(&mut conn)?;
+    let r = Reader(&mut conn, len);
+
+    if header.is_request {
+        return Err(net::Error::BadHeader.into());
+    }
+    if header.command == <Cmd::Resp as Response>::TYPE {
+        Ok(Ok(FromWire::from_wire(r, arena)?))
+    } else if header.command == CommandType::Error {
+        Ok(Err(FromWire::from_wire(r, arena)?))
+    } else {
+        Err(net::Error::BadHeader.into())
+    }
+}
+
+fn header_from_wire(
+    mut r: impl std::io::Read,
+) -> Result<(Header, usize), net::Error> {
+    let mut header_bytes = [0u8; 4];
+    r.read_exact(&mut header_bytes)
+        .map_err(|_| io::Error::Internal)?;
+    let [cmd_byte, req_bit, len_lo, len_hi] = header_bytes;
+
+    let header = Header {
+        command: CommandType::from_wire_value(cmd_byte)
+            .ok_or(net::Error::BadHeader)?,
+        is_request: match req_bit {
+            0 => false,
+            1 => true,
+            _ => return Err(net::Error::BadHeader),
+        },
+    };
+    let len = u16::from_le_bytes([len_lo, len_hi]);
+    Ok((header, len as usize))
+}
+
+pub struct Writer {
+    header: Header,
+    buf: Vec<u8>,
+}
+
+impl Writer {
+    pub fn new(header: Header) -> Self {
+        Self {
+            header,
+            buf: Vec::new(),
+        }
+    }
+
+    pub fn finish(self, mut w: impl std::io::Write) -> Result<(), net::Error> {
+        let [len_lo, len_hi] = (self.buf.len() as u16).to_le_bytes();
+        w.write_all(&[
+            self.header.command.to_wire_value(),
+            self.header.is_request as u8,
+            len_lo,
+            len_hi,
+        ])
+        .map_err(|_| io::Error::BufferExhausted)?;
+        w.write_all(&self.buf)
+            .map_err(|_| io::Error::BufferExhausted)?;
+        Ok(())
+    }
+}
+
+impl io::Write for Writer {
+    fn write_bytes(&mut self, buf: &[u8]) -> Result<(), io::Error> {
+        self.buf.extend_from_slice(buf);
+        Ok(())
+    }
+}
+
+pub struct TcpHostPort(Inner);
+
+struct Inner {
+    listener: TcpListener,
+    stream: Option<(Header, usize, TcpStream)>,
+    // This is currently necessary so that we know the full length of the
+    // output a priori.
+    output_buffer: Option<Writer>,
+}
+
+impl TcpHostPort {
+    pub fn bind(port: u16) -> Result<Self, net::Error> {
+        let listener = TcpListener::bind(("127.0.0.1", port))
+            .map_err(|_| io::Error::Internal)?;
+        Ok(Self(Inner {
+            listener,
+            stream: None,
+            output_buffer: None,
+        }))
+    }
+}
+
+impl HostPort for TcpHostPort {
+    fn receive(&mut self) -> Result<&mut dyn HostRequest, net::Error> {
+        let inner = &mut self.0;
+        inner.stream = None;
+
+        let (mut stream, _) =
+            inner.listener.accept().map_err(|_| io::Error::Internal)?;
+
+        let (header, len) = header_from_wire(&mut stream)?;
+        inner.stream = Some((header, len, stream));
+
+        Ok(inner)
+    }
+}
+
+impl HostRequest for Inner {
+    fn header(&self) -> Result<Header, net::Error> {
+        if self.output_buffer.is_some() {
+            return Err(net::Error::OutOfOrder);
+        }
+        self.stream
+            .as_ref()
+            .map(|(h, _, _)| *h)
+            .ok_or(net::Error::Disconnected)
+    }
+
+    fn payload(&mut self) -> Result<&mut dyn io::Read, net::Error> {
+        if self.stream.is_none() {
+            return Err(net::Error::Disconnected);
+        }
+        if self.output_buffer.is_some() {
+            return Err(net::Error::OutOfOrder);
+        }
+
+        Ok(self)
+    }
+
+    fn reply(
+        &mut self,
+        header: Header,
+    ) -> Result<&mut dyn HostResponse, net::Error> {
+        if self.stream.is_none() {
+            return Err(net::Error::Disconnected);
+        }
+        if self.output_buffer.is_some() {
+            return Err(net::Error::OutOfOrder);
+        }
+
+        self.output_buffer = Some(Writer::new(header));
+        Ok(self)
+    }
+}
+
+impl HostResponse for Inner {
+    fn sink(&mut self) -> Result<&mut dyn io::Write, net::Error> {
+        if self.stream.is_none() {
+            return Err(net::Error::Disconnected);
+        }
+
+        self.output_buffer
+            .as_mut()
+            .map(|w| w as &mut dyn io::Write)
+            .ok_or(net::Error::OutOfOrder)
+    }
+
+    fn finish(&mut self) -> Result<(), net::Error> {
+        match self {
+            Inner {
+                stream: Some((_, _, stream)),
+                output_buffer: Some(_),
+                ..
+            } => {
+                self.output_buffer.take().unwrap().finish(&mut *stream)?;
+                stream.flush().map_err(|_| io::Error::Internal)?;
+                self.stream = None;
+                self.output_buffer = None;
+                Ok(())
+            }
+            _ => Err(net::Error::Disconnected),
+        }
+    }
+}
+
+impl io::Read for Inner {
+    fn read_bytes(&mut self, out: &mut [u8]) -> Result<(), io::Error> {
+        let (_, len, stream) =
+            self.stream.as_mut().ok_or(io::Error::Internal)?;
+        if *len < out.len() {
+            return Err(io::Error::BufferExhausted);
+        }
+        stream.read_exact(out).map_err(|_| io::Error::Internal)?;
+        *len -= out.len();
+        Ok(())
+    }
+
+    fn remaining_data(&self) -> usize {
+        self.stream.as_ref().map(|(_, len, _)| *len).unwrap_or(0)
+    }
+}


### PR DESCRIPTION
`manticore-e2e` spawns a child processes to use as a "virtual RoT", speaking Cerberus over TCP. I intend to begin growing a proper conformance suite around this virtual RoT. This has three benefits:
1. e2e test for manticore itself are great.
2. We can eventually use this to test Azure's implementation as well.
3. This is intended to (eventually) be an example integration for interested Manticore users.

TODO: Add doc comments to everything.