### PR TITLE
[crypto] Make the signature APIs use iovec inputs

### DIFF
--- a/src/cert/x509.rs
+++ b/src/cert/x509.rs
@@ -93,7 +93,9 @@ pub fn parse<'cert>(
     let verifier = ciphers
         .verifier(sig_algo, key)
         .ok_or(Error::UnknownAlgorithm)?;
-    verifier.verify(sig, tbs).map_err(|_| Error::BadSignature)?;
+    verifier
+        .verify(&[tbs], sig)
+        .map_err(|_| Error::BadSignature)?;
 
     Ok(cert)
 }

--- a/src/cert/x509_test.rs
+++ b/src/cert/x509_test.rs
@@ -24,7 +24,7 @@ impl sig::Verify for NoVerify {
     type Error = ();
     fn verify(
         &mut self,
-        _: &[u8],
+        _: &[&[u8]],
         _: &[u8],
     ) -> core::result::Result<(), sig::Error> {
         Ok(())

--- a/src/crypto/ring/rsa.rs
+++ b/src/crypto/ring/rsa.rs
@@ -144,13 +144,18 @@ impl sig::Verify for Verify256 {
 
     fn verify(
         &mut self,
+        message_vec: &[&[u8]],
         signature: &[u8],
-        message: &[u8],
     ) -> Result<(), sig::VerifyError<Self>> {
+        let mut message = Vec::new();
+        for bytes in message_vec {
+            message.extend_from_slice(bytes);
+        }
+
         let scheme = &ring::signature::RSA_PKCS1_2048_8192_SHA256;
         self.key
             .key
-            .verify(scheme, message, signature)
+            .verify(scheme, &message, signature)
             .map_err(sig::Error::Custom)
     }
 }
@@ -171,14 +176,19 @@ impl sig::Sign for Sign256 {
 
     fn sign(
         &mut self,
-        message: &[u8],
+        message_vec: &[&[u8]],
         signature: &mut [u8],
     ) -> Result<(), sig::SignError<Self>> {
+        let mut message = Vec::new();
+        for bytes in message_vec {
+            message.extend_from_slice(bytes);
+        }
+
         let scheme = &ring::signature::RSA_PKCS1_SHA256;
         let rng = ring::rand::SystemRandom::new();
         self.keypair
             .keypair
-            .sign(scheme, &rng, message, signature)
+            .sign(scheme, &rng, &message, signature)
             .map_err(sig::Error::Custom)
     }
 }
@@ -204,14 +214,19 @@ mod tests {
         let mut engine = rsa.new_verifier(keypair.public()).unwrap();
 
         engine
-            .verify(testdata::RSA_2048_SHA256_SIG_PKCS1, testdata::PLAIN_TEXT)
+            .verify(
+                &[testdata::PLAIN_TEXT],
+                testdata::RSA_2048_SHA256_SIG_PKCS1,
+            )
             .unwrap();
 
         let mut signer = rsa.new_signer(keypair).unwrap();
         let mut generated_sig = vec![0; signer.sig_bytes()];
         signer
-            .sign(testdata::PLAIN_TEXT, &mut generated_sig)
+            .sign(&[testdata::PLAIN_TEXT], &mut generated_sig)
             .unwrap();
-        engine.verify(&generated_sig, testdata::PLAIN_TEXT).unwrap();
+        engine
+            .verify(&[testdata::PLAIN_TEXT], &generated_sig)
+            .unwrap();
     }
 }

--- a/src/manifest/container.rs
+++ b/src/manifest/container.rs
@@ -426,7 +426,7 @@ impl<'f, M: Manifest, F: Flash, Provenance> Container<'f, M, F, Provenance> {
         let sig =
             self.flash
                 .read_direct(self.signature_region(), verify_arena, 1)?;
-        sig_verify.verify(sig, &digest)?;
+        sig_verify.verify(&[&digest], sig)?;
         Ok(())
     }
 

--- a/src/manifest/owned/mod.rs
+++ b/src/manifest/owned/mod.rs
@@ -405,7 +405,7 @@ impl<E: Element> Container<E> {
         let mut signed = [0; 32];
         let mut signature = vec![0; signer.sig_bytes()];
         sha.hash_contiguous(&bytes, &mut signed)?;
-        signer.sign(&signed, &mut signature)?;
+        signer.sign(&[&signed], &mut signature)?;
         bytes.extend_from_slice(&signature);
 
         Ok(bytes)


### PR DESCRIPTION
This is mostly to enable zero-copy signing for things like CBOR and some
of the Cerberus challenge messages, which compute signatures over
disjoint buffers.