### PR TITLE
[mem] Allow inline arrays for BumpArena storage

### DIFF
--- a/src/protocol/macros.rs
+++ b/src/protocol/macros.rs
@@ -32,19 +32,19 @@ macro_rules! round_trip_test {
             use $crate::io::*;
             use $crate::mem::*;
             const BUF_LEN: usize = 1 << 10;
-            let mut buf = [0u8; BUF_LEN];
 
             let bytes: &[u8] = $bytes;
             let value: $ty = $ty $({ $($field: $field_val,)* })?;
 
             let mut bytes_reader = bytes;
-            let arena = BumpArena::new(&mut buf);
+            let arena = BumpArena::new(vec![0u8; BUF_LEN]);
             let deserialized = $ty::from_wire(&mut bytes_reader, &arena)
                 .expect("deserialization failed");
             assert_eq!(bytes_reader.len(), 0,
                 "expected bytes to be fully read");
             assert_eq!(deserialized, value);
 
+            let mut buf = vec![0u8; BUF_LEN];
             let mut cursor = Cursor::new(&mut buf);
             value.to_wire(&mut cursor).expect("serialization failed");
             assert_eq!(cursor.consumed_bytes(), bytes);


### PR DESCRIPTION
This rearranges the `unsafe` inside of `BumpArena` somewhat, but I've written comments describing why this is OK.