### PR TITLE
[ci] Run as many unit tests as possible on Miri

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -43,3 +43,13 @@ jobs:
 
     - name: Run e2e tests
       run: cargo test -v -p manticore-e2e -- run-tests
+
+  miri_tests:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install Miri
+      run: rustup +nightly-2021-07-27 component add miri
+    - name: Run tests under Miri
+      run: cargo +nightly-2021-07-27 miri test

--- a/src/cert/cwt/test.rs
+++ b/src/cert/cwt/test.rs
@@ -20,6 +20,7 @@ const ARRAY: u8 = 4;
 const MAP: u8 = 5;
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn self_signed() {
     let protected = raw_cbor!(MAP [
         // Algorithm.

--- a/src/cert/x509/test.rs
+++ b/src/cert/x509/test.rs
@@ -15,6 +15,7 @@ use crate::crypto::rsa::KeyPair as _;
 use crate::crypto::sig::NoVerify;
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn self_signed() {
     let cert = Cert::parse(
         testdata::X509_SELF_SIGNED,
@@ -31,6 +32,7 @@ fn self_signed() {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn explicit_key() {
     let keypair =
         ring::rsa::KeyPair::from_pkcs8(crypto::testdata::RSA_2048_PRIV_PKCS8)

--- a/src/crypto/ring/rsa.rs
+++ b/src/crypto/ring/rsa.rs
@@ -214,6 +214,7 @@ mod tests {
     use crate::crypto::testdata;
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn rsa() {
         let keypair =
             KeyPair::from_pkcs8(testdata::RSA_2048_PRIV_PKCS8).unwrap();

--- a/src/crypto/ring/sha256.rs
+++ b/src/crypto/ring/sha256.rs
@@ -75,6 +75,7 @@ mod tests {
     use crate::crypto::testdata;
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn sha() {
         let sha = Builder::new();
         let mut digest = sha256::Digest::default();

--- a/src/manifest/container.rs
+++ b/src/manifest/container.rs
@@ -555,6 +555,7 @@ pub(crate) mod test {
     // manifest type.
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn empty() {
         let sha = ring::sha256::Builder::new();
         let (mut rsa, mut signer) = testdata::rsa();
@@ -585,6 +586,7 @@ pub(crate) mod test {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn one_element() {
         let sha = ring::sha256::Builder::new();
         let (mut rsa, mut signer) = testdata::rsa();
@@ -622,6 +624,7 @@ pub(crate) mod test {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn with_child() {
         let sha = ring::sha256::Builder::new();
         let (mut rsa, mut signer) = testdata::rsa();

--- a/src/manifest/owned/pfm.rs
+++ b/src/manifest/owned/pfm.rs
@@ -520,6 +520,7 @@ mod test {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn round_trip() {
         let pfm = owned::Container {
             metadata: Metadata { version_id: 42 },

--- a/src/manifest/pfm.rs
+++ b/src/manifest/pfm.rs
@@ -833,6 +833,7 @@ mod test {
     use serde_json::from_str;
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn empty() {
         let sha = ring::sha256::Builder::new();
         let (mut rsa, mut signer) = test_rsa();
@@ -860,6 +861,7 @@ mod test {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn platform_id() {
         let sha = ring::sha256::Builder::new();
         let (mut rsa, mut signer) = test_rsa();
@@ -886,6 +888,7 @@ mod test {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn fw_versions() {
         let sha = ring::sha256::Builder::new();
         let (mut rsa, mut signer) = test_rsa();
@@ -1005,6 +1008,7 @@ mod test {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn baked_pfm1() {
         let sha = ring::sha256::Builder::new();
         let (mut rsa, mut signer) = test_rsa();


### PR DESCRIPTION
A handful of tests are currently disabled in Miri mode because they need to call into `ring`'s copy of BoringSSL.