### PR TITLE
[ci] Break off linting into its own job

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,7 +14,7 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build_and_test:
+  check_lints:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -23,6 +23,9 @@ jobs:
       run: cargo fmt -- --check --files-with-diff
     - name: Check clippy lints
       run: cargo clippy --verbose
+
+  build_and_test:
+    - uses: actions/checkout@v2
 
     - name: Build with default settings
       run: cargo build -v -p manticore


### PR DESCRIPTION
This should stop format/clippy errors from blocking the build
altogether.

Signed-off-by: Miguel Young de la Sota <mcyoung@google.com>