### PR TITLE
[e2e] Make it possible to use Rust's test harness for e2e tests

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -44,9 +44,6 @@ jobs:
     - name: Run tests
       run: cargo test --verbose
 
-    - name: Run e2e tests
-      run: cargo test -v -p manticore-e2e -- run-tests
-
   miri_tests:
     runs-on: ubuntu-latest
     steps:
@@ -56,3 +53,7 @@ jobs:
       run: rustup +nightly-2021-07-27 component add miri
     - name: Run tests under Miri
       run: cargo +nightly-2021-07-27 miri test
+
+  e2e_tests:
+    - name: Run end-to-end tests
+    - run: e2e/run.sh

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -3,9 +3,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 [package]
-name = "manticore-e2e"
+name = "e2e"
 version = "0.0.0"
 edition = "2018"
+publish = false
 
 authors = ["lowRISC Contributors"]
 license = "Apache-2.0"
@@ -17,6 +18,7 @@ description = "End-to-end tests for Manticore"
 manticore = { path = ".." }
 
 env_logger = "0.8"
+lazy_static = "1.4"
 log = "0.4"
 serde = "1.0"
 serde_json = "1.0"

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -18,5 +18,6 @@ manticore = { path = ".." }
 
 env_logger = "0.8"
 log = "0.4"
+serde = "1.0"
 serde_json = "1.0"
 structopt = "0.3.16"

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,9 +1,7 @@
 # End-to-end tests for Manticore.
 
-This crate operates as follows. When run as `./e2e run-tests`, it will
-re-exec a copy of the process via `./e2e serve`. This new process is a
-"virtual RoT", which is connected back to the parent over a TCP "bus".
-The parent can then actuate the virtual RoT as a sort of black box.
+This crate contains Manticore's end-to-end tests, which stand up and interact
+with a "virtual RoT" running as a subprocess over TCP.
 
 This crate serves two major purposes:
 1. To provide an easy way to black-box test Manticore; in the future, we'd
@@ -13,9 +11,17 @@ This crate serves two major purposes:
    understand how to build a Cerberus-compliant device using Manticore's
    toolkit.
 
-To actually run these tests against manticore, run do
-```
-cargo run -p manticore-e2e -- run-tests
-```
-If a port allocation error occurs, the `--port` flag may be used to specify one
-explicitly.
+We leverage Rust's unit test harness to run the tests. Running `cargo test` is
+insufficient, since the tests won't know where to find the virtual RoT binary.
+The binary must be passed explicitly via the `MANTICORE_E2E_TARGET_BINARY`
+environment variable for the tests to find. The `e2e/run.sh` script shows how
+to do this.
+
+It is possible to run non-Manticore binaries under the end-to-end tests, since
+they are not Manticore-specific. The only requirements are:
+- They accept the same command-line interface as the `e2e` binary.
+- Upon binding a TCP port, they must print `listening@<port>\n` to stdout, for
+  the test harness to find the OS-allocated TCP port.
+
+Currently, running these tests on a non-POSIX system is not supported.
+

--- a/e2e/run.sh
+++ b/e2e/run.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# Run Manticore's e2e tests. See the README.md for more details.
+
+# First, build the e2e binary itself, which acts as the server.
+#
+# --message-format=json is stable, and prints out newline-separated
+# JSON blobs that describe each cargo action. The action that outputs
+# the built binary will contain a `"executable":"<path>"` entry.
+export MANTICORE_E2E_TARGET_BINARY="$(
+  cargo build -p e2e --message-format=json \
+    | tr '\n' ' ' \
+    | perl -pe 's/^.+"executable":"(.+?)".+$/$1/g'
+)"
+
+# Now run the tests!
+# We forward the script arguments directly to the harness, to allow
+# for filtering. RUST_LOG=info can be used to enable log output.
+cargo test -p e2e -- $@

--- a/e2e/src/tcp.rs
+++ b/e2e/src/tcp.rs
@@ -216,9 +216,9 @@ struct Inner {
 }
 
 impl TcpHostPort {
-    /// Binds a new `TcpHostPort` to the given port.
-    pub fn bind(port: u16) -> Result<Self, net::Error> {
-        let listener = TcpListener::bind(("127.0.0.1", port)).map_err(|e| {
+    /// Binds a new `TcpHostPort` to an open port.
+    pub fn bind() -> Result<Self, net::Error> {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).map_err(|e| {
             log::error!("{}", e);
             net::Error::Io(io::Error::Internal)
         })?;
@@ -227,6 +227,11 @@ impl TcpHostPort {
             stream: None,
             output_buffer: None,
         }))
+    }
+
+    /// Returns the TCP port this `HostPort` is bound to.
+    pub fn port(&self) -> u16 {
+        self.0.listener.local_addr().unwrap().port()
     }
 }
 

--- a/e2e/src/tests/device_queries.rs
+++ b/e2e/src/tests/device_queries.rs
@@ -1,0 +1,57 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Tests for device-interrogation messages.
+
+use manticore::mem::BumpArena;
+
+use crate::pa_rot;
+
+#[test]
+fn firmware_version() {
+    use manticore::protocol::firmware_version::*;
+
+    let virt = pa_rot::Virtual::spawn(&pa_rot::Options {
+        firmware_version: b"my cool e2e test".to_vec(),
+        ..Default::default()
+    });
+
+    let mut arena = [0; 64];
+    let arena = BumpArena::new(&mut arena);
+    let resp = virt.send_local::<FirmwareVersion, _>(
+        FirmwareVersionRequest { index: 0 },
+        &arena,
+    );
+
+    let version = resp.unwrap().unwrap().version;
+    assert!(version.starts_with(b"my cool e2e test"));
+}
+
+#[test]
+fn device_id() {
+    use manticore::protocol::device_id::*;
+
+    let virt = pa_rot::Virtual::spawn(&pa_rot::Options {
+        device_id: DeviceIdentifier {
+            vendor_id: 0xc020,
+            device_id: 0x0001,
+            subsys_vendor_id: 0xffff,
+            subsys_id: 0xaa55,
+        },
+        ..Default::default()
+    });
+
+    let mut arena = [0; 64];
+    let arena = BumpArena::new(&mut arena);
+    let resp = virt.send_local::<DeviceId, _>(DeviceIdRequest, &arena);
+    assert_eq!(
+        resp.unwrap().unwrap().id,
+        DeviceIdentifier {
+            vendor_id: 0xc020,
+            device_id: 0x0001,
+            subsys_vendor_id: 0xffff,
+            subsys_id: 0xaa55,
+        }
+    );
+}


### PR DESCRIPTION
Different approach to #92, which avoids having to reinvent a test harness ourselves.