### PR TITLE
[ci] Fix a syntax error in CI config

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,6 +25,8 @@ jobs:
       run: cargo clippy --verbose
 
   build_and_test:
+    runs-on: ubuntu-latest
+    steps:
     - uses: actions/checkout@v2
 
     - name: Build with default settings


### PR DESCRIPTION
Modifying the CI configs apparently has hardly any guardrails. I have yet to find how to make it impossible to merge changes to configuration with syntax errors.