### PR TITLE
[crypto] Remove unnecessarilly-generic errors

### DIFF
--- a/fuzz/targets/x509_unsigned.rs
+++ b/fuzz/targets/x509_unsigned.rs
@@ -18,7 +18,6 @@ use manticore::protocol::capabilities;
 struct NoVerify;
 
 impl sig::Verify for NoVerify {
-    type Error = ();
     fn verify(
         &mut self,
         _: &[&[u8]],
@@ -35,7 +34,7 @@ impl sig::Ciphers for NoVerify {
         &'a mut self,
         _: sig::Algo,
         _: &sig::PublicKeyParams,
-    ) -> Option<&'a mut dyn sig::Verify<Error = ()>> {
+    ) -> Option<&'a mut dyn sig::Verify> {
         Some(self)
     }
 }

--- a/src/crypto/ring/sha256.rs
+++ b/src/crypto/ring/sha256.rs
@@ -4,8 +4,6 @@
 
 //! Implementations of [`crypto::sha256`] based on `ring`.
 
-use core::convert::Infallible;
-
 use ring::digest;
 
 use crate::crypto::sha256;
@@ -34,7 +32,7 @@ impl Default for Builder {
 impl sha256::Builder for Builder {
     type Hasher = Hasher;
 
-    fn new_hasher(&self) -> Result<Hasher, sha256::Error<Infallible>> {
+    fn new_hasher(&self) -> Result<Hasher, sha256::Error> {
         Ok(Hasher {
             ctx: digest::Context::new(&digest::SHA256),
         })
@@ -49,17 +47,12 @@ pub struct Hasher {
 }
 
 impl sha256::Hasher for Hasher {
-    type Error = Infallible;
-
-    fn write(&mut self, bytes: &[u8]) -> Result<(), sha256::Error<Infallible>> {
+    fn write(&mut self, bytes: &[u8]) -> Result<(), sha256::Error> {
         self.ctx.update(bytes);
         Ok(())
     }
 
-    fn finish(
-        self,
-        out: &mut sha256::Digest,
-    ) -> Result<(), sha256::Error<Infallible>> {
+    fn finish(self, out: &mut sha256::Digest) -> Result<(), sha256::Error> {
         let digest = self.ctx.finish();
         out.copy_from_slice(digest.as_ref());
         Ok(())

--- a/src/crypto/ring/sig.rs
+++ b/src/crypto/ring/sig.rs
@@ -7,7 +7,6 @@
 //! Requires the `std` feature flag to be enabled.
 
 use crate::crypto::ring::rsa;
-use crate::crypto::ring::Unspecified;
 use crate::crypto::rsa::Builder as _;
 use crate::crypto::sig;
 use crate::protocol::capabilities;
@@ -18,7 +17,7 @@ use crate::crypto;
 /// A [`sig::Ciphers`] built on top of `ring`.
 #[derive(Default)]
 pub struct Ciphers {
-    verifier: Option<Box<dyn sig::Verify<Error = Unspecified>>>,
+    verifier: Option<Box<dyn sig::Verify>>,
 }
 
 impl Ciphers {
@@ -29,8 +28,6 @@ impl Ciphers {
 }
 
 impl sig::Ciphers for Ciphers {
-    type Error = Unspecified;
-
     fn negotiate(&self, caps: &mut capabilities::Crypto) {
         use capabilities::*;
         *caps = Crypto {
@@ -48,7 +45,7 @@ impl sig::Ciphers for Ciphers {
         &'a mut self,
         algo: sig::Algo,
         key: &sig::PublicKeyParams,
-    ) -> Option<&'a mut dyn sig::Verify<Error = Unspecified>> {
+    ) -> Option<&'a mut dyn sig::Verify> {
         match (algo, key) {
             (
                 sig::Algo::RsaPkcs1Sha256,

--- a/src/crypto/rsa.rs
+++ b/src/crypto/rsa.rs
@@ -115,15 +115,12 @@ pub trait Builder<Algo> {
 
     /// Creates a new [`Verify`], primed with the given key, which may be used
     /// repeatedly to perform operations.
-    fn new_verifier(
-        &self,
-        key: Self::Key,
-    ) -> Result<Self::Verify, sig::VerifyError<Self::Verify>>;
+    fn new_verifier(&self, key: Self::Key) -> Result<Self::Verify, sig::Error>;
 
     /// Creates a new [`Sign`], primed with the given keypair, which may be
     /// used repeatedly to perform operations.
     fn new_signer(
         &self,
         keypair: Self::KeyPair,
-    ) -> Result<Self::Sign, sig::SignError<Self::Sign>>;
+    ) -> Result<Self::Sign, sig::Error>;
 }

--- a/src/manifest/mod.rs
+++ b/src/manifest/mod.rs
@@ -182,10 +182,10 @@ pub enum Error {
     BadSignatureLen,
 
     /// Indicates that an error occured inside of a hashing engine.
-    HashingError(sha256::Error),
+    HashError(sha256::Error),
 
     /// Indicates that a signature operation failed for some reason.
-    SignatureFailure,
+    SigError(sig::Error),
 }
 
 impl From<io::Error> for Error {
@@ -206,15 +206,15 @@ impl From<OutOfMemory> for Error {
     }
 }
 
-impl<E> From<sig::Error<E>> for Error {
-    fn from(_: sig::Error<E>) -> Self {
-        Self::SignatureFailure
+impl From<sig::Error> for Error {
+    fn from(e: sig::Error) -> Self {
+        Self::SigError(e)
     }
 }
 
-impl<E> From<sha256::Error<E>> for Error {
-    fn from(e: sha256::Error<E>) -> Self {
-        Self::HashingError(e.erased())
+impl From<sha256::Error> for Error {
+    fn from(e: sha256::Error) -> Self {
+        Self::HashError(e)
     }
 }
 

--- a/src/manifest/owned/mod.rs
+++ b/src/manifest/owned/mod.rs
@@ -180,15 +180,15 @@ pub enum EncodingError {
     SigError(sig::Error),
 }
 
-impl<E> From<sha256::Error<E>> for EncodingError {
-    fn from(e: sha256::Error<E>) -> Self {
-        Self::HashError(e.erased())
+impl From<sha256::Error> for EncodingError {
+    fn from(e: sha256::Error) -> Self {
+        Self::HashError(e)
     }
 }
 
-impl<E> From<sig::Error<E>> for EncodingError {
-    fn from(e: sig::Error<E>) -> Self {
-        Self::SigError(e.erased())
+impl From<sig::Error> for EncodingError {
+    fn from(e: sig::Error) -> Self {
+        Self::SigError(e)
     }
 }
 


### PR DESCRIPTION
Originally, there was a desire for custom implementations to be able to
spit out errors about their internals. In practice, this isn't a great
idea for two reasons:
- Unnecessary complexity due to extra type parameters.
- Leaking internal state of engines isn't very useful (or secure!).

Engine-specific errors will probably want to be logged via an
integration-specific side-channel.

Signed-off-by: Miguel Young de la Sota <mcyoung@google.com>