### PR TITLE
 [protocol] Merge `(From|To)WireError` into one

### DIFF
--- a/src/io/cursor.rs
+++ b/src/io/cursor.rs
@@ -14,10 +14,10 @@
 //! conjunction with [`ToWire`]:
 //! ```
 //! # use manticore::io::*;
-//! # use manticore::protocol::wire::*;
+//! # use manticore::protocol::wire::{self, *};
 //! # struct MyMessage;
 //! # impl ToWire for MyMessage {
-//! #     fn to_wire<W: Write>(&self, mut w: W) -> Result<(), ToWireError> {
+//! #     fn to_wire<W: Write>(&self, mut w: W) -> Result<(), wire::Error> {
 //! #         w.write_bytes(&[1, 2, 3, 4]);
 //! #         Ok(())
 //! #     }

--- a/src/protocol/challenge.rs
+++ b/src/protocol/challenge.rs
@@ -13,10 +13,9 @@ use crate::io::Read;
 use crate::io::Write;
 use crate::mem::Arena;
 use crate::mem::ArenaExt as _;
+use crate::protocol::wire;
 use crate::protocol::wire::FromWire;
-use crate::protocol::wire::FromWireError;
 use crate::protocol::wire::ToWire;
-use crate::protocol::wire::ToWireError;
 use crate::protocol::Command;
 use crate::protocol::CommandType;
 use crate::protocol::Request;
@@ -60,7 +59,7 @@ impl<'a> FromWire<'a> for ChallengeRequest<'a> {
     fn from_wire<R: Read, A: Arena>(
         mut r: R,
         arena: &'a A,
-    ) -> Result<Self, FromWireError> {
+    ) -> Result<Self, wire::Error> {
         let slot = r.read_le()?;
         let _: u8 = r.read_le()?;
         let nonce = arena.alloc::<[u8; 32]>()?;
@@ -70,7 +69,7 @@ impl<'a> FromWire<'a> for ChallengeRequest<'a> {
 }
 
 impl ToWire for ChallengeRequest<'_> {
-    fn to_wire<W: Write>(&self, mut w: W) -> Result<(), ToWireError> {
+    fn to_wire<W: Write>(&self, mut w: W) -> Result<(), wire::Error> {
         w.write_le(self.slot)?;
         w.write_le(0u8)?;
         w.write_bytes(self.nonce)?;
@@ -120,7 +119,7 @@ impl<'a> FromWire<'a> for ChallengeResponse<'a> {
     fn from_wire<R: Read, A: Arena>(
         mut r: R,
         arena: &'a A,
-    ) -> Result<Self, FromWireError> {
+    ) -> Result<Self, wire::Error> {
         let slot = r.read_le()?;
         let slot_mask = r.read_le()?;
         let min_version = r.read_le()?;
@@ -149,7 +148,7 @@ impl<'a> FromWire<'a> for ChallengeResponse<'a> {
 }
 
 impl ToWire for ChallengeResponse<'_> {
-    fn to_wire<W: Write>(&self, mut w: W) -> Result<(), ToWireError> {
+    fn to_wire<W: Write>(&self, mut w: W) -> Result<(), wire::Error> {
         w.write_le(self.slot)?;
         w.write_le(self.slot_mask)?;
         w.write_le(self.protocol_range.0)?;
@@ -161,7 +160,7 @@ impl ToWire for ChallengeResponse<'_> {
             self.pmr0
                 .len()
                 .try_into()
-                .map_err(|_| ToWireError::Io(io::Error::BufferExhausted))?,
+                .map_err(|_| wire::Error::Io(io::Error::BufferExhausted))?,
         )?;
         w.write_bytes(self.pmr0)?;
         w.write_bytes(self.signature)?;

--- a/src/protocol/device_id.rs
+++ b/src/protocol/device_id.rs
@@ -10,10 +10,9 @@
 use crate::io::Read;
 use crate::io::Write;
 use crate::mem::Arena;
+use crate::protocol::wire;
 use crate::protocol::wire::FromWire;
-use crate::protocol::wire::FromWireError;
 use crate::protocol::wire::ToWire;
-use crate::protocol::wire::ToWireError;
 use crate::protocol::Command;
 use crate::protocol::CommandType;
 use crate::protocol::Request;
@@ -54,13 +53,13 @@ impl<'a> FromWire<'a> for DeviceIdRequest {
     fn from_wire<R: Read, A: Arena>(
         _: R,
         _: &'a A,
-    ) -> Result<Self, FromWireError> {
+    ) -> Result<Self, wire::Error> {
         Ok(DeviceIdRequest)
     }
 }
 
 impl ToWire for DeviceIdRequest {
-    fn to_wire<W: Write>(&self, _: W) -> Result<(), ToWireError> {
+    fn to_wire<W: Write>(&self, _: W) -> Result<(), wire::Error> {
         Ok(())
     }
 }
@@ -83,14 +82,14 @@ impl<'a> FromWire<'a> for DeviceIdResponse {
     fn from_wire<R: Read, A: Arena>(
         mut r: R,
         a: &'a A,
-    ) -> Result<Self, FromWireError> {
+    ) -> Result<Self, wire::Error> {
         let id = DeviceIdentifier::from_wire(&mut r, a)?;
         Ok(Self { id })
     }
 }
 
 impl ToWire for DeviceIdResponse {
-    fn to_wire<W: Write>(&self, mut w: W) -> Result<(), ToWireError> {
+    fn to_wire<W: Write>(&self, mut w: W) -> Result<(), wire::Error> {
         self.id.to_wire(&mut w)?;
         Ok(())
     }
@@ -120,7 +119,7 @@ impl<'a> FromWire<'a> for DeviceIdentifier {
     fn from_wire<R: Read, A: Arena>(
         mut r: R,
         _: &'a A,
-    ) -> Result<Self, FromWireError> {
+    ) -> Result<Self, wire::Error> {
         let vendor_id = r.read_le::<u16>()?;
         let device_id = r.read_le::<u16>()?;
         let subsys_vendor_id = r.read_le::<u16>()?;
@@ -135,7 +134,7 @@ impl<'a> FromWire<'a> for DeviceIdentifier {
 }
 
 impl ToWire for DeviceIdentifier {
-    fn to_wire<W: Write>(&self, mut w: W) -> Result<(), ToWireError> {
+    fn to_wire<W: Write>(&self, mut w: W) -> Result<(), wire::Error> {
         w.write_le(self.vendor_id)?;
         w.write_le(self.device_id)?;
         w.write_le(self.subsys_vendor_id)?;

--- a/src/protocol/device_info.rs
+++ b/src/protocol/device_info.rs
@@ -11,10 +11,9 @@ use crate::io::Read;
 use crate::io::Write;
 use crate::mem::Arena;
 use crate::mem::ArenaExt as _;
+use crate::protocol::wire;
 use crate::protocol::wire::FromWire;
-use crate::protocol::wire::FromWireError;
 use crate::protocol::wire::ToWire;
-use crate::protocol::wire::ToWireError;
 use crate::protocol::Command;
 use crate::protocol::CommandType;
 use crate::protocol::Request;
@@ -63,14 +62,14 @@ impl<'a> FromWire<'a> for DeviceInfoRequest {
     fn from_wire<R: Read, A: Arena>(
         mut r: R,
         a: &'a A,
-    ) -> Result<Self, FromWireError> {
+    ) -> Result<Self, wire::Error> {
         let index = InfoIndex::from_wire(&mut r, a)?;
         Ok(Self { index })
     }
 }
 
 impl<'a> ToWire for DeviceInfoRequest {
-    fn to_wire<W: Write>(&self, mut w: W) -> Result<(), ToWireError> {
+    fn to_wire<W: Write>(&self, mut w: W) -> Result<(), wire::Error> {
         self.index.to_wire(&mut w)?;
         Ok(())
     }
@@ -99,7 +98,7 @@ impl<'a> FromWire<'a> for DeviceInfoResponse<'a> {
     fn from_wire<R: Read, A: Arena>(
         mut r: R,
         arena: &'a A,
-    ) -> Result<Self, FromWireError> {
+    ) -> Result<Self, wire::Error> {
         let len = r.remaining_data();
         let buf = arena.alloc_slice::<u8>(len)?;
         r.read_bytes(buf)?;
@@ -108,7 +107,7 @@ impl<'a> FromWire<'a> for DeviceInfoResponse<'a> {
 }
 
 impl ToWire for DeviceInfoResponse<'_> {
-    fn to_wire<W: Write>(&self, mut w: W) -> Result<(), ToWireError> {
+    fn to_wire<W: Write>(&self, mut w: W) -> Result<(), wire::Error> {
         w.write_bytes(self.info)?;
         Ok(())
     }

--- a/src/protocol/device_uptime.rs
+++ b/src/protocol/device_uptime.rs
@@ -14,10 +14,9 @@ use core::time::Duration;
 use crate::io::Read;
 use crate::io::Write;
 use crate::mem::Arena;
+use crate::protocol::wire;
 use crate::protocol::wire::FromWire;
-use crate::protocol::wire::FromWireError;
 use crate::protocol::wire::ToWire;
-use crate::protocol::wire::ToWireError;
 use crate::protocol::Command;
 use crate::protocol::CommandType;
 use crate::protocol::Request;
@@ -61,14 +60,14 @@ impl<'a> FromWire<'a> for DeviceUptimeRequest {
     fn from_wire<R: Read, A: Arena>(
         mut r: R,
         _: &'a A,
-    ) -> Result<Self, FromWireError> {
+    ) -> Result<Self, wire::Error> {
         let port_id = r.read_le::<u8>()?;
         Ok(Self { port_id })
     }
 }
 
 impl<'a> ToWire for DeviceUptimeRequest {
-    fn to_wire<W: Write>(&self, mut w: W) -> Result<(), ToWireError> {
+    fn to_wire<W: Write>(&self, mut w: W) -> Result<(), wire::Error> {
         w.write_le(self.port_id)?;
         Ok(())
     }
@@ -95,7 +94,7 @@ impl<'a> FromWire<'a> for DeviceUptimeResponse {
     fn from_wire<R: Read, A: Arena>(
         mut r: R,
         _: &'a A,
-    ) -> Result<Self, FromWireError> {
+    ) -> Result<Self, wire::Error> {
         let micros = r.read_le::<u32>()?;
         let uptime = Duration::from_micros(micros as u64);
         Ok(Self { uptime })
@@ -103,7 +102,7 @@ impl<'a> FromWire<'a> for DeviceUptimeResponse {
 }
 
 impl ToWire for DeviceUptimeResponse {
-    fn to_wire<W: Write>(&self, mut w: W) -> Result<(), ToWireError> {
+    fn to_wire<W: Write>(&self, mut w: W) -> Result<(), wire::Error> {
         let micros = self.uptime.as_micros() as u32;
         w.write_le(micros)?;
         Ok(())

--- a/src/protocol/firmware_version.rs
+++ b/src/protocol/firmware_version.rs
@@ -11,10 +11,9 @@ use crate::io::Read;
 use crate::io::Write;
 use crate::mem::Arena;
 use crate::mem::ArenaExt as _;
+use crate::protocol::wire;
 use crate::protocol::wire::FromWire;
-use crate::protocol::wire::FromWireError;
 use crate::protocol::wire::ToWire;
-use crate::protocol::wire::ToWireError;
 use crate::protocol::Command;
 use crate::protocol::CommandType;
 use crate::protocol::Request;
@@ -60,14 +59,14 @@ impl<'a> FromWire<'a> for FirmwareVersionRequest {
     fn from_wire<R: Read, A: Arena>(
         mut r: R,
         _: &'a A,
-    ) -> Result<Self, FromWireError> {
+    ) -> Result<Self, wire::Error> {
         let index = r.read_le()?;
         Ok(Self { index })
     }
 }
 
 impl<'a> ToWire for FirmwareVersionRequest {
-    fn to_wire<W: Write>(&self, mut w: W) -> Result<(), ToWireError> {
+    fn to_wire<W: Write>(&self, mut w: W) -> Result<(), wire::Error> {
         w.write_le(self.index)?;
         Ok(())
     }
@@ -94,7 +93,7 @@ impl<'a> FromWire<'a> for FirmwareVersionResponse<'a> {
     fn from_wire<R: Read, A: Arena>(
         mut r: R,
         arena: &'a A,
-    ) -> Result<Self, FromWireError> {
+    ) -> Result<Self, wire::Error> {
         let version: &mut [u8; 32] = arena.alloc::<[u8; 32]>()?;
         r.read_bytes(version)?;
         Ok(Self { version })
@@ -102,7 +101,7 @@ impl<'a> FromWire<'a> for FirmwareVersionResponse<'a> {
 }
 
 impl ToWire for FirmwareVersionResponse<'_> {
-    fn to_wire<W: Write>(&self, mut w: W) -> Result<(), ToWireError> {
+    fn to_wire<W: Write>(&self, mut w: W) -> Result<(), wire::Error> {
         w.write_bytes(self.version)?;
         Ok(())
     }

--- a/src/protocol/get_cert.rs
+++ b/src/protocol/get_cert.rs
@@ -10,10 +10,9 @@ use crate::io::Read;
 use crate::io::Write;
 use crate::mem::Arena;
 use crate::mem::ArenaExt as _;
+use crate::protocol::wire;
 use crate::protocol::wire::FromWire;
-use crate::protocol::wire::FromWireError;
 use crate::protocol::wire::ToWire;
-use crate::protocol::wire::ToWireError;
 use crate::protocol::Command;
 use crate::protocol::CommandType;
 use crate::protocol::Request;
@@ -58,7 +57,7 @@ impl<'a> FromWire<'a> for GetCertRequest {
     fn from_wire<R: Read, A: Arena>(
         mut r: R,
         _: &'a A,
-    ) -> Result<Self, FromWireError> {
+    ) -> Result<Self, wire::Error> {
         let slot = r.read_le()?;
         let cert_number = r.read_le()?;
         let offset = r.read_le()?;
@@ -73,7 +72,7 @@ impl<'a> FromWire<'a> for GetCertRequest {
 }
 
 impl<'a> ToWire for GetCertRequest {
-    fn to_wire<W: Write>(&self, mut w: W) -> Result<(), ToWireError> {
+    fn to_wire<W: Write>(&self, mut w: W) -> Result<(), wire::Error> {
         w.write_le(self.slot)?;
         w.write_le(self.cert_number)?;
         w.write_le(self.offset)?;
@@ -105,7 +104,7 @@ impl<'a> FromWire<'a> for GetCertResponse<'a> {
     fn from_wire<R: Read, A: Arena>(
         mut r: R,
         arena: &'a A,
-    ) -> Result<Self, FromWireError> {
+    ) -> Result<Self, wire::Error> {
         let slot = r.read_le()?;
         let cert_number = r.read_le()?;
 
@@ -121,7 +120,7 @@ impl<'a> FromWire<'a> for GetCertResponse<'a> {
 }
 
 impl ToWire for GetCertResponse<'_> {
-    fn to_wire<W: Write>(&self, mut w: W) -> Result<(), ToWireError> {
+    fn to_wire<W: Write>(&self, mut w: W) -> Result<(), wire::Error> {
         w.write_le(self.slot)?;
         w.write_le(self.cert_number)?;
         w.write_bytes(self.data)?;

--- a/src/protocol/get_digests.rs
+++ b/src/protocol/get_digests.rs
@@ -12,7 +12,6 @@ use core::convert::TryInto as _;
 use zerocopy::AsBytes as _;
 
 use crate::crypto::sha256;
-use crate::io;
 use crate::io::Read;
 use crate::io::Write;
 use crate::mem::Arena;
@@ -132,7 +131,7 @@ impl ToWire for GetDigestsResponse<'_> {
             .digests
             .len()
             .try_into()
-            .map_err(|_| wire::Error::Io(io::Error::BufferExhausted))?;
+            .map_err(|_| wire::Error::OutOfRange)?;
         w.write_le(digests_len)?;
         w.write_bytes(self.digests.as_bytes())?;
         Ok(())

--- a/src/protocol/macros.rs
+++ b/src/protocol/macros.rs
@@ -104,7 +104,7 @@ macro_rules! make_fuzz_safe {
         #[cfg(feature = "arbitrary-derive")]
         impl $crate::protocol::wire::ToWire for $wrapper_name {
             fn to_wire<W: $crate::io::Write>(&self, w: W)
-                -> Result<(), $crate::protocol::wire::ToWireError> {
+                -> Result<(), $crate::protocol::wire> {
                 $crate::protocol::wire::ToWire::to_wire(&$name {$(
                     $field: make_fuzz_safe!(@extract_ty,
                                             self.$field: $field_ty),

--- a/src/protocol/macros.rs
+++ b/src/protocol/macros.rs
@@ -104,7 +104,7 @@ macro_rules! make_fuzz_safe {
         #[cfg(feature = "arbitrary-derive")]
         impl $crate::protocol::wire::ToWire for $wrapper_name {
             fn to_wire<W: $crate::io::Write>(&self, w: W)
-                -> Result<(), $crate::protocol::wire> {
+                -> Result<(), $crate::protocol::wire::Error> {
                 $crate::protocol::wire::ToWire::to_wire(&$name {$(
                     $field: make_fuzz_safe!(@extract_ty,
                                             self.$field: $field_ty),

--- a/src/protocol/request_counter.rs
+++ b/src/protocol/request_counter.rs
@@ -12,10 +12,9 @@
 use crate::io::Read;
 use crate::io::Write;
 use crate::mem::Arena;
+use crate::protocol::wire;
 use crate::protocol::wire::FromWire;
-use crate::protocol::wire::FromWireError;
 use crate::protocol::wire::ToWire;
-use crate::protocol::wire::ToWireError;
 use crate::protocol::Command;
 use crate::protocol::CommandType;
 use crate::protocol::Request;
@@ -51,13 +50,13 @@ impl<'a> FromWire<'a> for RequestCounterRequest {
     fn from_wire<R: Read, A: Arena>(
         _: R,
         _: &'a A,
-    ) -> Result<Self, FromWireError> {
+    ) -> Result<Self, wire::Error> {
         Ok(RequestCounterRequest)
     }
 }
 
 impl<'a> ToWire for RequestCounterRequest {
-    fn to_wire<W: Write>(&self, _: W) -> Result<(), ToWireError> {
+    fn to_wire<W: Write>(&self, _: W) -> Result<(), wire::Error> {
         Ok(())
     }
 }
@@ -82,7 +81,7 @@ impl<'a> FromWire<'a> for RequestCounterResponse {
     fn from_wire<R: Read, A: Arena>(
         mut r: R,
         _: &'a A,
-    ) -> Result<Self, FromWireError> {
+    ) -> Result<Self, wire::Error> {
         let ok_count = r.read_le::<u16>()?;
         let err_count = r.read_le::<u16>()?;
         Ok(Self {
@@ -93,7 +92,7 @@ impl<'a> FromWire<'a> for RequestCounterResponse {
 }
 
 impl ToWire for RequestCounterResponse {
-    fn to_wire<W: Write>(&self, mut w: W) -> Result<(), ToWireError> {
+    fn to_wire<W: Write>(&self, mut w: W) -> Result<(), wire::Error> {
         w.write_le(self.ok_count)?;
         w.write_le(self.err_count)?;
         Ok(())

--- a/src/protocol/reset_counter.rs
+++ b/src/protocol/reset_counter.rs
@@ -11,10 +11,9 @@
 use crate::io::Read;
 use crate::io::Write;
 use crate::mem::Arena;
+use crate::protocol::wire;
 use crate::protocol::wire::FromWire;
-use crate::protocol::wire::FromWireError;
 use crate::protocol::wire::ToWire;
-use crate::protocol::wire::ToWireError;
 use crate::protocol::Command;
 use crate::protocol::CommandType;
 use crate::protocol::Request;
@@ -75,7 +74,7 @@ impl<'a> FromWire<'a> for ResetCounterRequest {
     fn from_wire<R: Read, A: Arena>(
         mut r: R,
         a: &'a A,
-    ) -> Result<Self, FromWireError> {
+    ) -> Result<Self, wire::Error> {
         let reset_type = ResetType::from_wire(&mut r, a)?;
         let port_id = r.read_le::<u8>()?;
         Ok(Self {
@@ -86,7 +85,7 @@ impl<'a> FromWire<'a> for ResetCounterRequest {
 }
 
 impl<'a> ToWire for ResetCounterRequest {
-    fn to_wire<W: Write>(&self, mut w: W) -> Result<(), ToWireError> {
+    fn to_wire<W: Write>(&self, mut w: W) -> Result<(), wire::Error> {
         self.reset_type.to_wire(&mut w)?;
         w.write_le(self.port_id)?;
         Ok(())
@@ -111,14 +110,14 @@ impl<'a> FromWire<'a> for ResetCounterResponse {
     fn from_wire<R: Read, A: Arena>(
         mut r: R,
         _: &'a A,
-    ) -> Result<Self, FromWireError> {
+    ) -> Result<Self, wire::Error> {
         let count = r.read_le::<u16>()?;
         Ok(Self { count })
     }
 }
 
 impl ToWire for ResetCounterResponse {
-    fn to_wire<W: Write>(&self, mut w: W) -> Result<(), ToWireError> {
+    fn to_wire<W: Write>(&self, mut w: W) -> Result<(), wire::Error> {
         w.write_le(self.count)?;
         Ok(())
     }


### PR DESCRIPTION
The distinction is essentially unnecessary, since ToWire was a subset of FromWire. Moreover, the OutOfRange error is potentially useful for ToWire in some cases.