### PR TITLE
[protocol] Fix a build error in some configurations

### DIFF
--- a/src/protocol/get_host_state.rs
+++ b/src/protocol/get_host_state.rs
@@ -23,7 +23,7 @@ use libfuzzer_sys::arbitrary::{self, Arbitrary};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-/// A command for requesting the host reset state
+/// A command for requesting the host reset state.
 ///
 /// Corresponds to [`CommandType::GetHostState`].
 pub enum GetHostState {}
@@ -38,7 +38,8 @@ impl<'a> Command<'a> for GetHostState {
 #[cfg_attr(feature = "arbitrary-derive", derive(Arbitrary))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct GetHostStateRequest {
-    port_id: u8,
+    /// The port that the device whose reset counter is being looked up.
+    pub port_id: u8,
 }
 make_fuzz_safe!(GetHostStateRequest);
 
@@ -60,14 +61,15 @@ impl<'a> ToWire for GetHostStateRequest {
     }
 }
 
-make_fuzz_safe! {
-    /// The [`GetHostState`] response.
-    #[derive(Clone, Copy, PartialEq, Eq, Debug)]
+/// The [`GetHostState`] response.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[cfg_attr(feature = "arbitrary-derive", derive(Arbitrary))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-    pub struct GetHostStateResponse as GHSWrap {
-        host_reset_state: HostResetState,
-    }
+pub struct GetHostStateResponse {
+    /// The returned state.
+    host_reset_state: HostResetState,
 }
+make_fuzz_safe!(GetHostStateResponse);
 
 wire_enum! {
     /// Host processor reset state


### PR DESCRIPTION
The failure is inside of a `protocol` macro, which is likely because I merged a contributor's PR in a bad way that CI failed to catch. See:
```rust
error: expected identifier
  --> src/protocol/macros.rs:89:13
   |
89 |               $field_vis $field: $field_ty,
   |               ^^^^^^^^^^
   | 
  ::: src/protocol/get_host_state.rs:63:1
   |
63 | / make_fuzz_safe! {
64 | |     /// The [`GetHostState`] response.
65 | |     #[derive(Clone, Copy, PartialEq, Eq, Debug)]
66 | | #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
...  |
69 | |     }
70 | | }
   | |_- in this macro invocation
```

GH's presubmits seem to be more of a suggestion than a hard guardrail sometimes...

Signed-off-by: Miguel Young de la Sota <mcyoung@google.com>