### PR TITLE
[fuzz] Make make_fuzz_safe! compose better

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ members = [".", "e2e", "tool", "testutil"]
 arrayvec = { version = "0.7", default_features = false }
 bitflags = "1.2.1"
 byteorder = { version = "1.3.4", default_features = false }
+paste = "1.0"
 static_assertions = "1.1.0"
 untrusted = "0.7"
 zerocopy = "0.5.0"

--- a/fuzz/gen/manticore_protocol_capabilities_DeviceCapabilities__req_to_wire.rs
+++ b/fuzz/gen/manticore_protocol_capabilities_DeviceCapabilities__req_to_wire.rs
@@ -15,9 +15,10 @@ use manticore::protocol::wire::ToWire;
 use manticore::protocol::FuzzSafe;
 
 use manticore::protocol::capabilities::DeviceCapabilities as C;
+type Req<'a> = <C as Command<'a>>::Req;
 
-fuzz_target!(|data: <<C as Command<'static>>::Req as FuzzSafe>::Safe| {
+fuzz_target!(|data: <Req<'static> as FuzzSafe>::Safe| {
     let mut out = [0u8; 1024];
-    let _ = data.to_wire(&mut &mut out[..]);
+    let _ = Req::from_safe(&data).to_wire(&mut &mut out[..]);
 });
 

--- a/fuzz/gen/manticore_protocol_capabilities_DeviceCapabilities__resp_to_wire.rs
+++ b/fuzz/gen/manticore_protocol_capabilities_DeviceCapabilities__resp_to_wire.rs
@@ -15,9 +15,10 @@ use manticore::protocol::wire::ToWire;
 use manticore::protocol::FuzzSafe;
 
 use manticore::protocol::capabilities::DeviceCapabilities as C;
+type Resp<'a> = <C as Command<'a>>::Req;
 
-fuzz_target!(|data: <<C as Command<'static>>::Resp as FuzzSafe>::Safe| {
+fuzz_target!(|data: <Resp<'static> as FuzzSafe>::Safe| {
     let mut out = [0u8; 1024];
-    let _ = data.to_wire(&mut &mut out[..]);
+    let _ = Resp::from_safe(&data).to_wire(&mut &mut out[..]);
 });
 

--- a/fuzz/gen/manticore_protocol_challenge_Challenge__req_to_wire.rs
+++ b/fuzz/gen/manticore_protocol_challenge_Challenge__req_to_wire.rs
@@ -15,9 +15,10 @@ use manticore::protocol::wire::ToWire;
 use manticore::protocol::FuzzSafe;
 
 use manticore::protocol::challenge::Challenge as C;
+type Req<'a> = <C as Command<'a>>::Req;
 
-fuzz_target!(|data: <<C as Command<'static>>::Req as FuzzSafe>::Safe| {
+fuzz_target!(|data: <Req<'static> as FuzzSafe>::Safe| {
     let mut out = [0u8; 1024];
-    let _ = data.to_wire(&mut &mut out[..]);
+    let _ = Req::from_safe(&data).to_wire(&mut &mut out[..]);
 });
 

--- a/fuzz/gen/manticore_protocol_challenge_Challenge__resp_to_wire.rs
+++ b/fuzz/gen/manticore_protocol_challenge_Challenge__resp_to_wire.rs
@@ -15,9 +15,10 @@ use manticore::protocol::wire::ToWire;
 use manticore::protocol::FuzzSafe;
 
 use manticore::protocol::challenge::Challenge as C;
+type Resp<'a> = <C as Command<'a>>::Req;
 
-fuzz_target!(|data: <<C as Command<'static>>::Resp as FuzzSafe>::Safe| {
+fuzz_target!(|data: <Resp<'static> as FuzzSafe>::Safe| {
     let mut out = [0u8; 1024];
-    let _ = data.to_wire(&mut &mut out[..]);
+    let _ = Resp::from_safe(&data).to_wire(&mut &mut out[..]);
 });
 

--- a/fuzz/gen/manticore_protocol_device_id_DeviceId__req_to_wire.rs
+++ b/fuzz/gen/manticore_protocol_device_id_DeviceId__req_to_wire.rs
@@ -15,9 +15,10 @@ use manticore::protocol::wire::ToWire;
 use manticore::protocol::FuzzSafe;
 
 use manticore::protocol::device_id::DeviceId as C;
+type Req<'a> = <C as Command<'a>>::Req;
 
-fuzz_target!(|data: <<C as Command<'static>>::Req as FuzzSafe>::Safe| {
+fuzz_target!(|data: <Req<'static> as FuzzSafe>::Safe| {
     let mut out = [0u8; 1024];
-    let _ = data.to_wire(&mut &mut out[..]);
+    let _ = Req::from_safe(&data).to_wire(&mut &mut out[..]);
 });
 

--- a/fuzz/gen/manticore_protocol_device_id_DeviceId__resp_to_wire.rs
+++ b/fuzz/gen/manticore_protocol_device_id_DeviceId__resp_to_wire.rs
@@ -15,9 +15,10 @@ use manticore::protocol::wire::ToWire;
 use manticore::protocol::FuzzSafe;
 
 use manticore::protocol::device_id::DeviceId as C;
+type Resp<'a> = <C as Command<'a>>::Req;
 
-fuzz_target!(|data: <<C as Command<'static>>::Resp as FuzzSafe>::Safe| {
+fuzz_target!(|data: <Resp<'static> as FuzzSafe>::Safe| {
     let mut out = [0u8; 1024];
-    let _ = data.to_wire(&mut &mut out[..]);
+    let _ = Resp::from_safe(&data).to_wire(&mut &mut out[..]);
 });
 

--- a/fuzz/gen/manticore_protocol_device_info_DeviceInfo__req_to_wire.rs
+++ b/fuzz/gen/manticore_protocol_device_info_DeviceInfo__req_to_wire.rs
@@ -15,9 +15,10 @@ use manticore::protocol::wire::ToWire;
 use manticore::protocol::FuzzSafe;
 
 use manticore::protocol::device_info::DeviceInfo as C;
+type Req<'a> = <C as Command<'a>>::Req;
 
-fuzz_target!(|data: <<C as Command<'static>>::Req as FuzzSafe>::Safe| {
+fuzz_target!(|data: <Req<'static> as FuzzSafe>::Safe| {
     let mut out = [0u8; 1024];
-    let _ = data.to_wire(&mut &mut out[..]);
+    let _ = Req::from_safe(&data).to_wire(&mut &mut out[..]);
 });
 

--- a/fuzz/gen/manticore_protocol_device_info_DeviceInfo__resp_to_wire.rs
+++ b/fuzz/gen/manticore_protocol_device_info_DeviceInfo__resp_to_wire.rs
@@ -15,9 +15,10 @@ use manticore::protocol::wire::ToWire;
 use manticore::protocol::FuzzSafe;
 
 use manticore::protocol::device_info::DeviceInfo as C;
+type Resp<'a> = <C as Command<'a>>::Req;
 
-fuzz_target!(|data: <<C as Command<'static>>::Resp as FuzzSafe>::Safe| {
+fuzz_target!(|data: <Resp<'static> as FuzzSafe>::Safe| {
     let mut out = [0u8; 1024];
-    let _ = data.to_wire(&mut &mut out[..]);
+    let _ = Resp::from_safe(&data).to_wire(&mut &mut out[..]);
 });
 

--- a/fuzz/gen/manticore_protocol_device_uptime_DeviceUptime__req_to_wire.rs
+++ b/fuzz/gen/manticore_protocol_device_uptime_DeviceUptime__req_to_wire.rs
@@ -15,9 +15,10 @@ use manticore::protocol::wire::ToWire;
 use manticore::protocol::FuzzSafe;
 
 use manticore::protocol::device_uptime::DeviceUptime as C;
+type Req<'a> = <C as Command<'a>>::Req;
 
-fuzz_target!(|data: <<C as Command<'static>>::Req as FuzzSafe>::Safe| {
+fuzz_target!(|data: <Req<'static> as FuzzSafe>::Safe| {
     let mut out = [0u8; 1024];
-    let _ = data.to_wire(&mut &mut out[..]);
+    let _ = Req::from_safe(&data).to_wire(&mut &mut out[..]);
 });
 

--- a/fuzz/gen/manticore_protocol_device_uptime_DeviceUptime__resp_to_wire.rs
+++ b/fuzz/gen/manticore_protocol_device_uptime_DeviceUptime__resp_to_wire.rs
@@ -15,9 +15,10 @@ use manticore::protocol::wire::ToWire;
 use manticore::protocol::FuzzSafe;
 
 use manticore::protocol::device_uptime::DeviceUptime as C;
+type Resp<'a> = <C as Command<'a>>::Req;
 
-fuzz_target!(|data: <<C as Command<'static>>::Resp as FuzzSafe>::Safe| {
+fuzz_target!(|data: <Resp<'static> as FuzzSafe>::Safe| {
     let mut out = [0u8; 1024];
-    let _ = data.to_wire(&mut &mut out[..]);
+    let _ = Resp::from_safe(&data).to_wire(&mut &mut out[..]);
 });
 

--- a/fuzz/gen/manticore_protocol_firmware_version_FirmwareVersion__req_to_wire.rs
+++ b/fuzz/gen/manticore_protocol_firmware_version_FirmwareVersion__req_to_wire.rs
@@ -15,9 +15,10 @@ use manticore::protocol::wire::ToWire;
 use manticore::protocol::FuzzSafe;
 
 use manticore::protocol::firmware_version::FirmwareVersion as C;
+type Req<'a> = <C as Command<'a>>::Req;
 
-fuzz_target!(|data: <<C as Command<'static>>::Req as FuzzSafe>::Safe| {
+fuzz_target!(|data: <Req<'static> as FuzzSafe>::Safe| {
     let mut out = [0u8; 1024];
-    let _ = data.to_wire(&mut &mut out[..]);
+    let _ = Req::from_safe(&data).to_wire(&mut &mut out[..]);
 });
 

--- a/fuzz/gen/manticore_protocol_firmware_version_FirmwareVersion__resp_to_wire.rs
+++ b/fuzz/gen/manticore_protocol_firmware_version_FirmwareVersion__resp_to_wire.rs
@@ -15,9 +15,10 @@ use manticore::protocol::wire::ToWire;
 use manticore::protocol::FuzzSafe;
 
 use manticore::protocol::firmware_version::FirmwareVersion as C;
+type Resp<'a> = <C as Command<'a>>::Req;
 
-fuzz_target!(|data: <<C as Command<'static>>::Resp as FuzzSafe>::Safe| {
+fuzz_target!(|data: <Resp<'static> as FuzzSafe>::Safe| {
     let mut out = [0u8; 1024];
-    let _ = data.to_wire(&mut &mut out[..]);
+    let _ = Resp::from_safe(&data).to_wire(&mut &mut out[..]);
 });
 

--- a/fuzz/gen/manticore_protocol_get_cert_GetCert__req_to_wire.rs
+++ b/fuzz/gen/manticore_protocol_get_cert_GetCert__req_to_wire.rs
@@ -15,9 +15,10 @@ use manticore::protocol::wire::ToWire;
 use manticore::protocol::FuzzSafe;
 
 use manticore::protocol::get_cert::GetCert as C;
+type Req<'a> = <C as Command<'a>>::Req;
 
-fuzz_target!(|data: <<C as Command<'static>>::Req as FuzzSafe>::Safe| {
+fuzz_target!(|data: <Req<'static> as FuzzSafe>::Safe| {
     let mut out = [0u8; 1024];
-    let _ = data.to_wire(&mut &mut out[..]);
+    let _ = Req::from_safe(&data).to_wire(&mut &mut out[..]);
 });
 

--- a/fuzz/gen/manticore_protocol_get_cert_GetCert__resp_to_wire.rs
+++ b/fuzz/gen/manticore_protocol_get_cert_GetCert__resp_to_wire.rs
@@ -15,9 +15,10 @@ use manticore::protocol::wire::ToWire;
 use manticore::protocol::FuzzSafe;
 
 use manticore::protocol::get_cert::GetCert as C;
+type Resp<'a> = <C as Command<'a>>::Req;
 
-fuzz_target!(|data: <<C as Command<'static>>::Resp as FuzzSafe>::Safe| {
+fuzz_target!(|data: <Resp<'static> as FuzzSafe>::Safe| {
     let mut out = [0u8; 1024];
-    let _ = data.to_wire(&mut &mut out[..]);
+    let _ = Resp::from_safe(&data).to_wire(&mut &mut out[..]);
 });
 

--- a/fuzz/gen/manticore_protocol_get_digests_GetDigests__req_to_wire.rs
+++ b/fuzz/gen/manticore_protocol_get_digests_GetDigests__req_to_wire.rs
@@ -15,9 +15,10 @@ use manticore::protocol::wire::ToWire;
 use manticore::protocol::FuzzSafe;
 
 use manticore::protocol::get_digests::GetDigests as C;
+type Req<'a> = <C as Command<'a>>::Req;
 
-fuzz_target!(|data: <<C as Command<'static>>::Req as FuzzSafe>::Safe| {
+fuzz_target!(|data: <Req<'static> as FuzzSafe>::Safe| {
     let mut out = [0u8; 1024];
-    let _ = data.to_wire(&mut &mut out[..]);
+    let _ = Req::from_safe(&data).to_wire(&mut &mut out[..]);
 });
 

--- a/fuzz/gen/manticore_protocol_get_digests_GetDigests__resp_to_wire.rs
+++ b/fuzz/gen/manticore_protocol_get_digests_GetDigests__resp_to_wire.rs
@@ -15,9 +15,10 @@ use manticore::protocol::wire::ToWire;
 use manticore::protocol::FuzzSafe;
 
 use manticore::protocol::get_digests::GetDigests as C;
+type Resp<'a> = <C as Command<'a>>::Req;
 
-fuzz_target!(|data: <<C as Command<'static>>::Resp as FuzzSafe>::Safe| {
+fuzz_target!(|data: <Resp<'static> as FuzzSafe>::Safe| {
     let mut out = [0u8; 1024];
-    let _ = data.to_wire(&mut &mut out[..]);
+    let _ = Resp::from_safe(&data).to_wire(&mut &mut out[..]);
 });
 

--- a/fuzz/gen/manticore_protocol_get_host_state_GetHostState__req_to_wire.rs
+++ b/fuzz/gen/manticore_protocol_get_host_state_GetHostState__req_to_wire.rs
@@ -15,9 +15,10 @@ use manticore::protocol::wire::ToWire;
 use manticore::protocol::FuzzSafe;
 
 use manticore::protocol::get_host_state::GetHostState as C;
+type Req<'a> = <C as Command<'a>>::Req;
 
-fuzz_target!(|data: <<C as Command<'static>>::Req as FuzzSafe>::Safe| {
+fuzz_target!(|data: <Req<'static> as FuzzSafe>::Safe| {
     let mut out = [0u8; 1024];
-    let _ = data.to_wire(&mut &mut out[..]);
+    let _ = Req::from_safe(&data).to_wire(&mut &mut out[..]);
 });
 

--- a/fuzz/gen/manticore_protocol_get_host_state_GetHostState__resp_to_wire.rs
+++ b/fuzz/gen/manticore_protocol_get_host_state_GetHostState__resp_to_wire.rs
@@ -15,9 +15,10 @@ use manticore::protocol::wire::ToWire;
 use manticore::protocol::FuzzSafe;
 
 use manticore::protocol::get_host_state::GetHostState as C;
+type Resp<'a> = <C as Command<'a>>::Req;
 
-fuzz_target!(|data: <<C as Command<'static>>::Resp as FuzzSafe>::Safe| {
+fuzz_target!(|data: <Resp<'static> as FuzzSafe>::Safe| {
     let mut out = [0u8; 1024];
-    let _ = data.to_wire(&mut &mut out[..]);
+    let _ = Resp::from_safe(&data).to_wire(&mut &mut out[..]);
 });
 

--- a/fuzz/gen/manticore_protocol_request_counter_RequestCounter__req_to_wire.rs
+++ b/fuzz/gen/manticore_protocol_request_counter_RequestCounter__req_to_wire.rs
@@ -15,9 +15,10 @@ use manticore::protocol::wire::ToWire;
 use manticore::protocol::FuzzSafe;
 
 use manticore::protocol::request_counter::RequestCounter as C;
+type Req<'a> = <C as Command<'a>>::Req;
 
-fuzz_target!(|data: <<C as Command<'static>>::Req as FuzzSafe>::Safe| {
+fuzz_target!(|data: <Req<'static> as FuzzSafe>::Safe| {
     let mut out = [0u8; 1024];
-    let _ = data.to_wire(&mut &mut out[..]);
+    let _ = Req::from_safe(&data).to_wire(&mut &mut out[..]);
 });
 

--- a/fuzz/gen/manticore_protocol_request_counter_RequestCounter__resp_to_wire.rs
+++ b/fuzz/gen/manticore_protocol_request_counter_RequestCounter__resp_to_wire.rs
@@ -15,9 +15,10 @@ use manticore::protocol::wire::ToWire;
 use manticore::protocol::FuzzSafe;
 
 use manticore::protocol::request_counter::RequestCounter as C;
+type Resp<'a> = <C as Command<'a>>::Req;
 
-fuzz_target!(|data: <<C as Command<'static>>::Resp as FuzzSafe>::Safe| {
+fuzz_target!(|data: <Resp<'static> as FuzzSafe>::Safe| {
     let mut out = [0u8; 1024];
-    let _ = data.to_wire(&mut &mut out[..]);
+    let _ = Resp::from_safe(&data).to_wire(&mut &mut out[..]);
 });
 

--- a/fuzz/gen/manticore_protocol_reset_counter_ResetCounter__req_to_wire.rs
+++ b/fuzz/gen/manticore_protocol_reset_counter_ResetCounter__req_to_wire.rs
@@ -15,9 +15,10 @@ use manticore::protocol::wire::ToWire;
 use manticore::protocol::FuzzSafe;
 
 use manticore::protocol::reset_counter::ResetCounter as C;
+type Req<'a> = <C as Command<'a>>::Req;
 
-fuzz_target!(|data: <<C as Command<'static>>::Req as FuzzSafe>::Safe| {
+fuzz_target!(|data: <Req<'static> as FuzzSafe>::Safe| {
     let mut out = [0u8; 1024];
-    let _ = data.to_wire(&mut &mut out[..]);
+    let _ = Req::from_safe(&data).to_wire(&mut &mut out[..]);
 });
 

--- a/fuzz/gen/manticore_protocol_reset_counter_ResetCounter__resp_to_wire.rs
+++ b/fuzz/gen/manticore_protocol_reset_counter_ResetCounter__resp_to_wire.rs
@@ -15,9 +15,10 @@ use manticore::protocol::wire::ToWire;
 use manticore::protocol::FuzzSafe;
 
 use manticore::protocol::reset_counter::ResetCounter as C;
+type Resp<'a> = <C as Command<'a>>::Req;
 
-fuzz_target!(|data: <<C as Command<'static>>::Resp as FuzzSafe>::Safe| {
+fuzz_target!(|data: <Resp<'static> as FuzzSafe>::Safe| {
     let mut out = [0u8; 1024];
-    let _ = data.to_wire(&mut &mut out[..]);
+    let _ = Resp::from_safe(&data).to_wire(&mut &mut out[..]);
 });
 

--- a/fuzz/templates/req_to_wire.rs.tpl
+++ b/fuzz/templates/req_to_wire.rs.tpl
@@ -15,9 +15,10 @@ use manticore::protocol::wire::ToWire;
 use manticore::protocol::FuzzSafe;
 
 use {ty} as C;
+type Req<'a> = <C as Command<'a>>::Req;
 
-fuzz_target!(|data: <<C as Command<'static>>::Req as FuzzSafe>::Safe| {{
+fuzz_target!(|data: <Req<'static> as FuzzSafe>::Safe| {{
     let mut out = [0u8; 1024];
-    let _ = data.to_wire(&mut &mut out[..]);
+    let _ = Req::from_safe(&data).to_wire(&mut &mut out[..]);
 }});
 

--- a/fuzz/templates/resp_to_wire.rs.tpl
+++ b/fuzz/templates/resp_to_wire.rs.tpl
@@ -15,9 +15,10 @@ use manticore::protocol::wire::ToWire;
 use manticore::protocol::FuzzSafe;
 
 use {ty} as C;
+type Resp<'a> = <C as Command<'a>>::Req;
 
-fuzz_target!(|data: <<C as Command<'static>>::Resp as FuzzSafe>::Safe| {{
+fuzz_target!(|data: <Resp<'static> as FuzzSafe>::Safe| {{
     let mut out = [0u8; 1024];
-    let _ = data.to_wire(&mut &mut out[..]);
+    let _ = Resp::from_safe(&data).to_wire(&mut &mut out[..]);
 }});
 

--- a/src/protocol/challenge.rs
+++ b/src/protocol/challenge.rs
@@ -41,14 +41,14 @@ make_fuzz_safe! {
     /// The [`Challenge`] request.
     #[derive(Clone, Copy, PartialEq, Eq, Debug)]
     #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-    pub struct ChallengeRequest<'wire> as CRWrap {
+    pub struct ChallengeRequest<'wire> {
         /// The slot number of the chain to read from.
         pub slot: u8,
         /// A requester-chosen random nonce.
         #[cfg_attr(feature = "serde",
                    serde(deserialize_with = "crate::serde::de_u8_array_ref"))]
         #[cfg_attr(feature = "serde", serde(borrow))]
-        pub nonce: (&'wire [u8; 32]),
+        pub nonce: &'wire [u8; 32],
     }
 }
 
@@ -82,7 +82,7 @@ make_fuzz_safe! {
     /// The [`Challenge`] response.
     #[derive(Clone, Copy, PartialEq, Eq, Debug)]
     #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-    pub struct ChallengeResponse<'wire> as CR2Wrap {
+    pub struct ChallengeResponse<'wire> {
         /// The slot number of the chain to read from.
         pub slot: u8,
         /// The "certificate slot mask" (Cerberus does not elaborate further).
@@ -97,18 +97,18 @@ make_fuzz_safe! {
         #[cfg_attr(feature = "serde",
                    serde(deserialize_with = "crate::serde::de_u8_array_ref"))]
         #[cfg_attr(feature = "serde", serde(borrow))]
-        pub nonce: (&'wire [u8; 32]),
+        pub nonce: &'wire [u8; 32],
         /// The number of "components" used to generate PMR0.
         pub pmr0_components: u8,
         /// The value of the PMR0 measurement.
         #[cfg_attr(feature = "serde", serde(borrow))]
-        pub pmr0: (&'wire [u8]),
+        pub pmr0: &'wire [u8],
         /// The challenge signature.
         ///
         /// This is a signature over the concatenation of the corresponding
         /// request and the response up to the signature.
         #[cfg_attr(feature = "serde", serde(borrow))]
-        pub signature: (&'wire [u8]),
+        pub signature: &'wire [u8],
     }
 }
 

--- a/src/protocol/device_info.rs
+++ b/src/protocol/device_info.rs
@@ -79,14 +79,14 @@ make_fuzz_safe! {
     /// The [`DeviceInfo`] response.
     #[derive(Clone, Copy, PartialEq, Eq, Debug)]
     #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-    pub struct DeviceInfoResponse<'wire> as DIRWrap {
+    pub struct DeviceInfoResponse<'wire> {
         /// The requested information, in some binary format.
         ///
         /// The format of the response depends on which information index was sent.
         /// Only `0x00` is specified by Cerberus, which is reqired to produce the
         /// "Unique Chip Identifier".
         #[cfg_attr(feature = "serde", serde(borrow))]
-        pub info: (&'wire [u8]),
+        pub info: &'wire [u8],
     }
 }
 

--- a/src/protocol/firmware_version.rs
+++ b/src/protocol/firmware_version.rs
@@ -77,12 +77,12 @@ make_fuzz_safe! {
     /// The [`FirmwareVersion`] response.
     #[derive(Clone, Copy, PartialEq, Eq, Debug)]
     #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-    pub struct FirmwareVersionResponse<'wire> as FVRWrap {
+    pub struct FirmwareVersionResponse<'wire> {
         /// The firmware version. In practice, this is usually an ASCII string.
         #[cfg_attr(feature = "serde",
                    serde(deserialize_with = "crate::serde::de_u8_array_ref"))]
         #[cfg_attr(feature = "serde", serde(borrow))]
-        pub version: (&'wire [u8; 32]),
+        pub version: &'wire [u8; 32],
     }
 }
 

--- a/src/protocol/get_cert.rs
+++ b/src/protocol/get_cert.rs
@@ -86,14 +86,14 @@ make_fuzz_safe! {
     /// The [`GetCert`] response.
     #[derive(Clone, Copy, PartialEq, Eq, Debug)]
     #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-    pub struct GetCertResponse<'wire> as GCRWrap {
+    pub struct GetCertResponse<'wire> {
         /// The slot number of the chain to read from.
         pub slot: u8,
         /// The number of the cert to request, indexed from the root.
         pub cert_number: u8,
         /// The data read from the certificate.
         #[cfg_attr(feature = "serde", serde(borrow))]
-        pub data: (&'wire [u8]),
+        pub data: &'wire [u8],
     }
 }
 

--- a/src/protocol/get_digests.rs
+++ b/src/protocol/get_digests.rs
@@ -93,13 +93,13 @@ make_fuzz_safe! {
     /// The [`GetDigests`] response.
     #[derive(Clone, Copy, PartialEq, Eq, Debug)]
     #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-    pub struct GetDigestsResponse<'wire> as FVRWrap {
+    pub struct GetDigestsResponse<'wire> {
         /// The digests of each certificate in the chain, starting from the
         /// root.
         #[cfg_attr(feature = "serde",
                    serde(deserialize_with = "crate::serde::de_slice_of_u8_arrays"))]
         #[cfg_attr(feature = "serde", serde(borrow))]
-        pub digests: (&'wire [sha256::Digest]),
+        pub digests: &'wire [sha256::Digest],
     }
 }
 

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -58,7 +58,7 @@ use serde::{Deserialize, Serialize};
 #[macro_use]
 mod macros;
 #[cfg(feature = "arbitrary-derive")]
-pub use macros::FuzzSafe;
+pub use macros::fuzz::FuzzSafe;
 
 #[macro_use]
 pub mod wire;


### PR DESCRIPTION
make_fuzz_safe! is used to generate 'static versions of structs, so
that they can derive() the Arbitrary trait. Unfortunately, the existing
mechanism was quite hacky, and did not make appropriate use of the trait
system. This commit refactors it into a trait-friendly version.