### PR TITLE
[e2e] Improve debugging output

### DIFF
--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -17,6 +17,7 @@ description = "End-to-end tests for Manticore"
 [dependencies]
 manticore = { path = ".." }
 
+ctor = "0.1"
 env_logger = "0.8"
 lazy_static = "1.4"
 log = "0.4"

--- a/e2e/run.sh
+++ b/e2e/run.sh
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Run Manticore's e2e tests. See the README.md for more details.
+set -e
 
 # First, build the e2e binary itself, which acts as the server.
 #
@@ -11,6 +12,7 @@
 # JSON blobs that describe each cargo action. The action that outputs
 # the built binary will contain a `"executable":"<path>"` entry.
 export MANTICORE_E2E_TARGET_BINARY="$(
+  set -e
   cargo build -p e2e --message-format=json \
     | tr '\n' ' ' \
     | perl -pe 's/^.+"executable":"(.+?)".+$/$1/g'

--- a/e2e/src/pa_rot.rs
+++ b/e2e/src/pa_rot.rs
@@ -102,26 +102,21 @@ impl Virtual {
             static ref BINARY_PATH: OsString = match env::var_os(TARGET_BINARY) {
                 Some(bin) => bin,
                 None => {
-                    // In order to blow up the test binary, we need to call
-                    // abort ourselves. Not only that, but we need to be clever
-                    // to defeat the standard library's test output capture...
-                    use std::os::unix::io::FromRawFd;
+                    use std::io;
                     use std::io::Write;
-                    use std::fs::File;
                     use std::process;
 
-                    #[allow(unsafe_code)]
-                    let mut stderr = unsafe { File::from_raw_fd(2) };
                     let _ = writeln!(
-                        stderr,
+                        io::stderr(),
                         "Could not find environment variable {}; aborting.",
                         TARGET_BINARY
                     );
                     let _ = writeln!(
-                        stderr,
+                        io::stderr(),
                         "Consider using the e2e/run.sh script, instead."
                     );
-                    process::abort();
+
+                    process::exit(255);
                 }
             };
         }

--- a/e2e/src/pa_rot.rs
+++ b/e2e/src/pa_rot.rs
@@ -135,8 +135,22 @@ impl Virtual {
         let mut child = Command::new(Self::target_binary())
             .args(&["--start-pa-rot-with-options", &opts])
             .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
             .spawn()
             .expect("failed to spawn server subprocess");
+
+        // Forward stderr through the eprint! macro, so that tests can capture
+        // it.
+        let mut stderr = BufReader::new(child.stderr.take().unwrap());
+        let mut line = String::new();
+        let _ = std::thread::spawn(move || loop {
+            line.clear();
+            match stderr.read_line(&mut line) {
+                Ok(_) => eprint!("{}", line),
+                Err(e) if e.kind() == std::io::ErrorKind::BrokenPipe => break,
+                Err(e) => panic!("unexpected error from virtual rot: {}", e),
+            }
+        });
 
         // Wait until the child signals it's ready by writing a line to stdout.
         let mut stdout = BufReader::new(child.stdout.take().unwrap());


### PR DESCRIPTION
This makes logs captures from a subprocess be treated as "test output" so the Rust test harness can filter it appropriately.
We achieve this by spawning a thread to forward stderr manually.

We also set up logging in the test harness itself.