### PR TITLE
[session] Create an interface for managing session keys

### DIFF
--- a/e2e/src/pa_rot.rs
+++ b/e2e/src/pa_rot.rs
@@ -26,6 +26,7 @@ use manticore::protocol::capabilities;
 use manticore::protocol::device_id::DeviceIdentifier;
 use manticore::server;
 use manticore::server::pa_rot::PaRot;
+use manticore::session::ring::Session;
 
 use crate::tcp;
 use crate::tcp::TcpHostPort;
@@ -279,6 +280,7 @@ pub fn serve(opts: Options) -> ! {
         signer.as_mut().map(|s| s as _),
     )
     .unwrap();
+    let mut session = Session::new();
 
     let mut server = PaRot::new(manticore::server::pa_rot::Options {
         identity: &identity,
@@ -286,6 +288,7 @@ pub fn serve(opts: Options) -> ! {
         sha: &sha,
         ciphers: &mut ciphers,
         trust_chain: &mut trust_chain,
+        session: &mut session,
         pmr0: &opts.pmr0,
         device_id: opts.device_id,
         networking,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,3 +63,4 @@ pub mod manifest;
 pub mod mem;
 pub mod net;
 pub mod server;
+pub mod session;

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -1,0 +1,141 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Cerberus session management.
+//!
+//! A Cerberus cryptographic session is created via the usual ECDH scheme, using
+//! [SP 800-108] as the KDF.
+//!
+//! # Key Derivation
+//!
+//! The KDF is specified by the NIST document [SP 800-108]. This document
+//! defines a family of KDFs, which are parametrized over a mode and a PRF.
+//! Cerberus uses the "counter" mode and HMAC with SHA-256 as its PRF.
+//! This actually boils down the KDF to a single HMAC operation:
+//!
+//! ```text
+//! session_key := HMAC(ecdh_material, 0x00000001 || L || 0x00 || C || 0x0100)
+//! ```
+//!
+//! where each integer is encoded big-endian. The ECDH exchange itself must
+//! use the P-256 curve. Implementations of [`Session`] must use this exact
+//! algorithm.
+//!
+//! [SP 800-108]: https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-108.pdf
+
+#[cfg(doc)]
+use crate::protocol;
+
+#[cfg(all(feature = "ring", feature = "std"))]
+pub mod ring;
+
+/// An error returned by an ECDH operation.
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub enum Error {
+    /// Indicates that one of the state-transitioning functions was called
+    /// on an incorrect state.
+    ///
+    /// For example, [`Session::finish_ecdh()`] can only be called after
+    /// [`Session::begin_ecdh()`] is called.
+    BadStateTransition,
+    /// Indicates an unspecified, internal error.
+    Unspecified,
+}
+
+/// A secret key returned by a [`Session`].
+pub type Key = [u8; 256 / 8];
+
+/// A manager for a Cerberus session, usable by either the host (the client)
+/// or the device (the server).
+///
+/// A `Session` is a state machine with four states:
+/// 1.  "Inactive": the starting state, indicating no session.
+///         - This state may be entered via [`Session::destroy_session()`] at
+///           any time.
+/// 2.  "Ready": the session is configured with the challenge nonces, ready for
+///     ECDH to begin.
+///         - This state may be entered via [`Session::create_session()`] at
+///           any time.
+/// 3.  "Agreement": an ephemeral ECDH private key has been created, and is
+///     pending receipt of the peer's public key to complete the ECDH
+///     transaction.
+///         - This state may be entered via [`Session::begin_ecdh()`], but only
+///           from the "Ready" or "Active" states.
+///         - [`Session::begin_ecdh()`] may be called on an active session to
+///           reestablish it.
+/// 4.  "Active": a session has been established, and [`Session::aes_key()`]
+///     and [`Session::hmac_key()`] will produce the negotiated keys.
+///         - This state may be entered via [`Session::finish_ecdh()`], but only
+///           from the "Ready" state.
+///
+/// All transition failures must leave the `Session` as-is, except for
+/// [`Session::finish_ecdh()`], which must bring it back to the "Ready" state
+/// on failure. It is a programmer error to call [`Session::finish_ecdh()`]
+/// out-of-order, since it's intended to be called with
+/// [`Session::begin_ecdh()`] in the context of request. This transition can
+/// only fail if the entire ECDH exchange fails.
+///
+/// Users will move through the states like so:
+/// 1.  When a device receives a [`protocol::challenge`] request that wants to
+///     establish a session later, its `Session` enters the "ready" state; once
+///     the response arrives, the host enters the "ready" state too.
+/// 2.  The host enters the "agreement" state and sends a
+///     [`protocol::key_exchange`] request to the device with the fresh public
+///     key.
+/// 3.  The device also enters the "agreement" state, and then immediately
+///     transitions to "active" using the host's public key. It then sends its
+///     public key, along with an HMAC of its certificate using the session's
+///     HMAC key, to the host.
+/// 4.  After verifying the signature over the public keys, the host enters the
+///     "active" state using the device's public key, and verifies the HMAC in
+///     the response.
+/// 5.  The device returns to the "inactive" state when receiving a
+///     session-destroying [`protocol::key_exchange`] request. Upon success,
+///     the host also enters the "inactive" state.
+///
+/// See the [module documentation][self] for information on the key derivation
+/// function used to create the HMAC and encryption keys.
+pub trait Session {
+    /// Begins a new session.
+    ///
+    /// Sessions begin when a successful [`protocol::challenge`] command is
+    /// completed. The challenge produces two nonces as a byproduct, which are
+    /// used as the basis for the session.
+    ///
+    /// This function destroys any prior existing session.
+    fn create_session(
+        &mut self,
+        req_nonce: &[u8],
+        resp_nonce: &[u8],
+    ) -> Result<(), Error>;
+
+    /// Destroys a session without creating a new one.
+    fn destroy_session(&mut self) -> Result<(), Error>;
+
+    /// Returns the maximum number of bytes needed to encode `our_key` in
+    /// [`Self::begin_ecdh()`].
+    fn ephemeral_bytes(&self) -> usize;
+
+    /// Begins an ECDH agreement.
+    ///
+    /// A fresh public key of length at most [`Session::ephemeral_bytes()`] is
+    /// written to `our_key`. On success, returns the length of this key.
+    ///
+    /// `our_key` will be an ECC key using the DER encoding.
+    fn begin_ecdh(&mut self, our_key: &mut [u8]) -> Result<usize, Error>;
+
+    /// Completes the ECDH agreement, establishing an active session.
+    ///
+    /// `their_key` should contain the public key from the response to an
+    /// appropriate [`protocol::key_exchange`] request.
+    ///
+    /// `their_key` must be an ECC key using the DER encoding.
+    fn finish_ecdh(&mut self, their_key: &[u8]) -> Result<(), Error>;
+
+    /// Returns the current session's AES-GCM encryption key, if a session exists.
+    fn aes_key(&self) -> Option<&Key>;
+
+    /// Returns the current session's HMAC key, if a session exists.
+    fn hmac_key(&self) -> Option<&Key>;
+}

--- a/src/session/ring.rs
+++ b/src/session/ring.rs
@@ -1,0 +1,203 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+//! An implementation of [`session::Session`] based on [`ring`].
+//!
+//! Requires the `std` feature flag to be enabled.
+
+use core::mem;
+
+use ring::agreement as ecdh;
+use ring::hmac;
+
+use crate::session;
+
+/// A [`ring`]-based [`session::Session`].
+pub struct Session {
+    conn: Option<Connection>,
+    rand: ring::rand::SystemRandom,
+}
+
+struct Connection {
+    req_nonce: Box<[u8]>,
+    resp_nonce: Box<[u8]>,
+    keys: Keys,
+}
+
+enum Keys {
+    None,
+    Ecdh(ecdh::EphemeralPrivateKey),
+    Session {
+        aes_key: session::Key,
+        hmac_key: session::Key,
+    },
+}
+
+impl Session {
+    /// Creates a new inactive `Session`.
+    pub fn new() -> Self {
+        Self {
+            conn: None,
+            rand: ring::rand::SystemRandom::new(),
+        }
+    }
+}
+
+impl Default for Session {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl session::Session for Session {
+    fn create_session(
+        &mut self,
+        req_nonce: &[u8],
+        resp_nonce: &[u8],
+    ) -> Result<(), session::Error> {
+        self.conn = Some(Connection {
+            req_nonce: req_nonce.into(),
+            resp_nonce: resp_nonce.into(),
+            keys: Keys::None,
+        });
+        Ok(())
+    }
+
+    fn destroy_session(&mut self) -> Result<(), session::Error> {
+        self.conn = None;
+        Ok(())
+    }
+
+    fn ephemeral_bytes(&self) -> usize {
+        // Two 32-byte point coordinates, plus the 0x04 header.
+        64 + 1
+    }
+
+    fn begin_ecdh(
+        &mut self,
+        our_key: &mut [u8],
+    ) -> Result<usize, session::Error> {
+        let conn = self
+            .conn
+            .as_mut()
+            .ok_or(session::Error::BadStateTransition)?;
+        let key =
+            ecdh::EphemeralPrivateKey::generate(&ecdh::ECDH_P256, &self.rand)
+                .map_err(|_| session::Error::Unspecified)?;
+
+        let public = key
+            .compute_public_key()
+            .map_err(|_| session::Error::Unspecified)?;
+        let out = our_key
+            .get_mut(..public.as_ref().len())
+            .ok_or(session::Error::Unspecified)?;
+        out.copy_from_slice(public.as_ref());
+
+        conn.keys = Keys::Ecdh(key);
+        Ok(out.len())
+    }
+
+    fn finish_ecdh(&mut self, their_key: &[u8]) -> Result<(), session::Error> {
+        let conn = self
+            .conn
+            .as_mut()
+            .ok_or(session::Error::BadStateTransition)?;
+
+        let our_key = match mem::replace(&mut conn.keys, Keys::None) {
+            Keys::Ecdh(our_key) => our_key,
+            _ => return Err(session::Error::BadStateTransition),
+        };
+        let their_key =
+            ecdh::UnparsedPublicKey::new(&ecdh::ECDH_P256, their_key);
+
+        conn.keys = ecdh::agree_ephemeral(
+            our_key,
+            &their_key,
+            session::Error::Unspecified,
+            |material| {
+                let aes_key = sp800_108_hmac256(
+                    material,
+                    &conn.req_nonce,
+                    &conn.resp_nonce,
+                );
+                let hmac_key = sp800_108_hmac256(
+                    material,
+                    &conn.resp_nonce,
+                    &conn.req_nonce,
+                );
+                Ok(Keys::Session { aes_key, hmac_key })
+            },
+        )?;
+        Ok(())
+    }
+
+    fn aes_key(&self) -> Option<&session::Key> {
+        match &self.conn {
+            Some(Connection {
+                keys: Keys::Session { aes_key, .. },
+                ..
+            }) => Some(aes_key),
+            _ => None,
+        }
+    }
+
+    fn hmac_key(&self) -> Option<&session::Key> {
+        match &self.conn {
+            Some(Connection {
+                keys: Keys::Session { hmac_key, .. },
+                ..
+            }) => Some(hmac_key),
+            _ => None,
+        }
+    }
+}
+
+/// Computes an SP 800-108 KDF with the Cerberus parametrization.
+fn sp800_108_hmac256(key: &[u8], label: &[u8], context: &[u8]) -> session::Key {
+    let key = hmac::Key::new(hmac::HMAC_SHA256, key);
+    let mut ctx = hmac::Context::with_key(&key);
+    ctx.update(&1u32.to_be_bytes());
+    ctx.update(label);
+    ctx.update(&[0]);
+    ctx.update(context);
+    ctx.update(&256u16.to_be_bytes());
+    let tag = ctx.sign();
+
+    let mut key = session::Key::default();
+    key.copy_from_slice(tag.as_ref());
+    key
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::session::Session as _;
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn agreement() {
+        let mut host = Session::new();
+        let mut device = Session::new();
+
+        let req_nonce = [0x5eu8; 32];
+        let resp_nonce = [0x7au8; 32];
+
+        host.create_session(&req_nonce, &resp_nonce).unwrap();
+        device.create_session(&req_nonce, &resp_nonce).unwrap();
+
+        let mut hkey = vec![0; host.ephemeral_bytes()];
+        let key_len = host.begin_ecdh(&mut hkey).unwrap();
+        let hkey = &hkey[..key_len];
+
+        let mut dkey = vec![0; host.ephemeral_bytes()];
+        let key_len = device.begin_ecdh(&mut dkey).unwrap();
+        let dkey = &dkey[..key_len];
+
+        device.finish_ecdh(hkey).unwrap();
+        host.finish_ecdh(dkey).unwrap();
+
+        assert_eq!(host.aes_key(), device.aes_key());
+        assert_eq!(host.hmac_key(), device.hmac_key());
+    }
+}


### PR DESCRIPTION
Also includes part of an implementation of session estabilishment in the PA-RoT server.

The implementation is incomplete; I need to re-write the SHA-2/HMAC interfaces first.