### PR TITLE
[meta] Add dependency on `extend` to cut down boilerplate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ members = [".", "e2e", "tool", "testutil"]
 arrayvec = { version = "0.7", default_features = false }
 bitflags = "1.2.1"
 byteorder = { version = "1.3.4", default_features = false }
+extend = "1.1"
 paste = "1.0"
 static_assertions = "1.1.0"
 untrusted = "0.7"

--- a/src/hardware/flash.rs
+++ b/src/hardware/flash.rs
@@ -213,41 +213,17 @@ unsafe impl<F: Flash> Flash for &mut F {
 ///
 /// Note that this trait is implemened for `&impl Flash`, which is the reason
 /// for the slightly odd signature.
-pub trait FlashExt<'flash> {
+#[extend::ext(name = FlashExt)]
+pub impl<F: Flash + ?Sized> F {
     /// Reads a value of type `T`.
     ///
     /// See [`ArenaExt::alloc()`].
-    fn read_object<'b: 'c, 'c, T>(
-        self,
+    fn read_object<'a: 'c, 'b: 'c, 'c, T>(
+        &'a self,
         offset: u32,
         arena: &'b dyn Arena,
     ) -> Result<&'c T, Error>
     where
-        'flash: 'c,
-        T: AsBytes + FromBytes + Copy;
-
-    /// Reads a slice of type `[T]`.
-    ///
-    /// See [`ArenaExt::alloc_slice()`].
-    fn read_slice<'b: 'c, 'c, T>(
-        self,
-        offset: u32,
-        n: usize,
-        arena: &'b dyn Arena,
-    ) -> Result<&'c [T], Error>
-    where
-        'flash: 'c,
-        T: AsBytes + FromBytes + Copy;
-}
-
-impl<'flash, F: Flash> FlashExt<'flash> for &'flash F {
-    fn read_object<'b: 'c, 'c, T>(
-        self,
-        offset: u32,
-        arena: &'b dyn Arena,
-    ) -> Result<&'c T, Error>
-    where
-        'flash: 'c,
         T: AsBytes + FromBytes + Copy,
     {
         let bytes = self.read_direct(
@@ -261,14 +237,16 @@ impl<'flash, F: Flash> FlashExt<'flash> for &'flash F {
         Ok(lv.into_ref())
     }
 
-    fn read_slice<'b: 'c, 'c, T>(
-        self,
+    /// Reads a slice of type `[T]`.
+    ///
+    /// See [`ArenaExt::alloc_slice()`].
+    fn read_slice<'a: 'c, 'b: 'c, 'c, T>(
+        &'a self,
         offset: u32,
         n: usize,
         arena: &'b dyn Arena,
     ) -> Result<&'c [T], Error>
     where
-        'flash: 'c,
         T: AsBytes + FromBytes + Copy,
     {
         let bytes_requested =

--- a/src/io/read.rs
+++ b/src/io/read.rs
@@ -42,20 +42,14 @@ pub trait Read {
 assert_obj_safe!(Read);
 
 /// Convenience functions for reading integers from a [`Read`].
-pub trait ReadInt: Read {
+#[extend::ext(name = ReadInt)]
+pub impl<R: Read + ?Sized> R {
     /// Reads a little-endian integer.
-    ///
-    /// # Note
-    /// Do not implement this function yourself. Callers are not required to
-    /// call it in order to actually perform a read, so whether or not it is
-    /// called is an implementation detail.
     #[inline]
     fn read_le<I: LeInt>(&mut self) -> Result<I, io::Error> {
         I::read_from(self)
     }
 }
-
-impl<R: Read + ?Sized> ReadInt for R {}
 
 /// A [`Read`] that may, as an optimization, zero-copy read data for the
 /// lifetime `'a`.
@@ -90,7 +84,8 @@ pub unsafe trait ReadZero<'a>: Read + 'a {
 }
 
 /// Convenience functions for direct reads, exposed as a trait.
-pub trait ReadZeroExt<'a>: ReadZero<'a> {
+#[extend::ext(name = ReadZeroExt)]
+pub impl<'a, R: ReadZero<'a> + ?Sized> R {
     /// Reads a value of type `T`.
     ///
     /// See [`ArenaExt::alloc()`].
@@ -119,7 +114,6 @@ pub trait ReadZeroExt<'a>: ReadZero<'a> {
         Ok(lv.into_slice())
     }
 }
-impl<'a, R: ReadZero<'a> + ?Sized> ReadZeroExt<'a> for R {}
 
 impl<R: Read + ?Sized> Read for &mut R {
     #[inline]


### PR DESCRIPTION
Signed-off-by: Miguel Young de la Sota <mcyoung@google.com>