### PR TITLE
[meta] Use `impl dyn Trait` as the object-safety assert idiom

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ arrayvec = { version = "0.7", default_features = false }
 bitflags = "1.2.1"
 byteorder = { version = "1.3.4", default_features = false }
 paste = "1.0"
-static_assertions = "1.1.0"
 untrusted = "0.7"
 zerocopy = "0.5.0"
 

--- a/src/cert/chain.rs
+++ b/src/cert/chain.rs
@@ -43,6 +43,7 @@ pub trait TrustChain {
     /// Returns `None` if no such chain is present.
     fn signer(&mut self, slot: u8) -> Option<&mut dyn sig::Sign>;
 }
+impl dyn TrustChain {} // Ensure object-safe.
 
 /// A simple trust chain with only one slot.
 pub struct SimpleChain<'cert, const LEN: usize> {

--- a/src/crypto/csrng.rs
+++ b/src/crypto/csrng.rs
@@ -22,3 +22,4 @@ pub trait Csrng {
     /// Fills `buf` with random bytes.
     fn fill(&mut self, buf: &mut [u8]) -> Result<(), Error>;
 }
+impl dyn Csrng {} // Ensure object-safe.

--- a/src/crypto/sig.rs
+++ b/src/crypto/sig.rs
@@ -32,6 +32,7 @@ pub trait Verify {
         signature: &[u8],
     ) -> Result<(), Error>;
 }
+impl dyn Verify {} // Ensure object-safe.
 
 /// An signing engine, already primed with a keypair.
 ///
@@ -55,6 +56,7 @@ pub trait Sign {
         signature: &mut [u8],
     ) -> Result<usize, Error>;
 }
+impl dyn Sign {} // Ensure object-safe.
 
 /// Public key parameters extracted from a certificate.
 ///
@@ -142,6 +144,7 @@ pub trait Ciphers {
         key: &PublicKeyParams,
     ) -> Option<&'a mut dyn Verify>;
 }
+impl dyn Ciphers {} // Ensure object-safe.
 
 /// A [`Ciphers`] that blindly accepts all signatures, for testing purposes.
 #[cfg(test)]

--- a/src/hardware/flash.rs
+++ b/src/hardware/flash.rs
@@ -16,8 +16,6 @@ use core::alloc::Layout;
 use core::convert::TryInto;
 use core::mem;
 
-use static_assertions::assert_obj_safe;
-
 use zerocopy::AsBytes;
 use zerocopy::FromBytes;
 use zerocopy::LayoutVerified;
@@ -143,7 +141,7 @@ pub unsafe trait Flash {
         Ok(())
     }
 }
-assert_obj_safe!(Flash);
+impl dyn Flash {} // Ensure object-safety.
 
 unsafe impl<F: Flash> Flash for &F {
     #[inline]

--- a/src/hardware/mod.rs
+++ b/src/hardware/mod.rs
@@ -30,6 +30,7 @@ pub trait Identity {
     /// value of unspecified format.
     fn unique_device_identity(&self) -> &[u8];
 }
+impl dyn Identity {} // Ensure object-safe.
 
 /// Provides access to device reset-related information for a particular
 /// device.
@@ -45,6 +46,7 @@ pub trait Reset {
     /// best-effort.
     fn uptime(&self) -> Duration;
 }
+impl dyn Reset {} // Ensure object-safe.
 
 #[cfg(test)]
 pub(crate) mod fake {

--- a/src/io/read.rs
+++ b/src/io/read.rs
@@ -9,8 +9,6 @@
 use core::alloc::Layout;
 use core::mem;
 
-use static_assertions::assert_obj_safe;
-
 use zerocopy::AsBytes;
 use zerocopy::FromBytes;
 use zerocopy::LayoutVerified;
@@ -39,7 +37,7 @@ pub trait Read {
     /// Returns the number of bytes still available to read.
     fn remaining_data(&self) -> usize;
 }
-assert_obj_safe!(Read);
+impl dyn Read {} // Ensure object-safety.
 
 /// Convenience functions for reading integers from a [`Read`].
 pub trait ReadInt: Read {

--- a/src/io/write.rs
+++ b/src/io/write.rs
@@ -6,8 +6,6 @@
 
 use core::mem;
 
-use static_assertions::assert_obj_safe;
-
 use crate::io;
 use crate::io::endian::LeInt;
 
@@ -38,8 +36,7 @@ pub trait Write {
         val.write_to(self)
     }
 }
-
-assert_obj_safe!(Write);
+impl dyn Write {} // Ensure object-safety.
 
 impl<W: Write + ?Sized> Write for &'_ mut W {
     #[inline]

--- a/src/mem/arena.rs
+++ b/src/mem/arena.rs
@@ -12,8 +12,6 @@ use core::cell::UnsafeCell;
 use core::marker::PhantomData;
 use core::slice;
 
-use static_assertions::assert_obj_safe;
-
 use zerocopy::AsBytes;
 use zerocopy::FromBytes;
 use zerocopy::LayoutVerified;
@@ -118,8 +116,7 @@ pub unsafe trait Arena {
     /// ```
     fn reset(&mut self);
 }
-
-assert_obj_safe!(Arena);
+impl dyn Arena {} // Ensure object-safety.
 
 /// Convenience functions for arenas, exposed as a trait.
 ///

--- a/src/net.rs
+++ b/src/net.rs
@@ -16,7 +16,6 @@
 #![allow(missing_docs)]
 
 use core::cell::Cell;
-use static_assertions::assert_obj_safe;
 
 use crate::io;
 use crate::io::Cursor;
@@ -130,7 +129,7 @@ pub trait HostPort<'req> {
     /// can be used to respond to the request.
     fn receive(&mut self) -> Result<&mut dyn HostRequest<'req>, Error>;
 }
-assert_obj_safe!(HostPort);
+impl dyn HostPort<'_> {} // Ensure object-safety.
 
 /// Provides the "request" half of a transaction with a host.
 ///
@@ -211,7 +210,7 @@ pub trait DevicePort {
     /// On success returns the response.
     fn receive_response(&mut self) -> Result<&mut dyn DeviceResponse, Error>;
 }
-assert_obj_safe!(DevicePort);
+impl dyn DevicePort {} // Ensure object-safety.
 
 /// Provides the "response" half of a transaction with a device.
 ///


### PR DESCRIPTION
To test for object safety, we simply need to utter the type `dyn Trait`; if the trait is not object-safe, its `dyn` cannot be uttered.

This is what the macro we were using was basically already doing, but this lets us drop a dependency.

Signed-off-by: Miguel Young de la Sota <mcyoung@google.com>