### PR TITLE
[protocol] Add a richer API for declaring message-specific errors

### DIFF
--- a/src/protocol/capabilities.rs
+++ b/src/protocol/capabilities.rs
@@ -24,6 +24,7 @@ use crate::protocol::wire::ToWire;
 use crate::protocol::wire::WireEnum;
 use crate::protocol::Command;
 use crate::protocol::CommandType;
+use crate::protocol::NoSpecificError;
 use crate::protocol::Request;
 use crate::protocol::Response;
 
@@ -40,6 +41,7 @@ pub enum DeviceCapabilities {}
 impl Command<'_> for DeviceCapabilities {
     type Req = DeviceCapabilitiesRequest;
     type Resp = DeviceCapabilitiesResponse;
+    type Error = NoSpecificError;
 }
 
 /// The [`DeviceCapabilities`] request.

--- a/src/protocol/challenge.rs
+++ b/src/protocol/challenge.rs
@@ -16,6 +16,7 @@ use crate::mem::Arena;
 use crate::protocol::wire;
 use crate::protocol::wire::FromWire;
 use crate::protocol::wire::ToWire;
+use crate::protocol::ChallengeError;
 use crate::protocol::Command;
 use crate::protocol::CommandType;
 use crate::protocol::Request;
@@ -34,6 +35,7 @@ pub enum Challenge {}
 impl<'wire> Command<'wire> for Challenge {
     type Req = ChallengeRequest<'wire>;
     type Resp = ChallengeResponse<'wire>;
+    type Error = ChallengeError;
 }
 
 make_fuzz_safe! {

--- a/src/protocol/device_id.rs
+++ b/src/protocol/device_id.rs
@@ -16,6 +16,7 @@ use crate::protocol::wire::FromWire;
 use crate::protocol::wire::ToWire;
 use crate::protocol::Command;
 use crate::protocol::CommandType;
+use crate::protocol::NoSpecificError;
 use crate::protocol::Request;
 use crate::protocol::Response;
 
@@ -37,6 +38,7 @@ pub enum DeviceId {}
 impl Command<'_> for DeviceId {
     type Req = DeviceIdRequest;
     type Resp = DeviceIdResponse;
+    type Error = NoSpecificError;
 }
 
 /// The [`DeviceId`] request.

--- a/src/protocol/device_info.rs
+++ b/src/protocol/device_info.rs
@@ -16,6 +16,7 @@ use crate::protocol::wire::FromWire;
 use crate::protocol::wire::ToWire;
 use crate::protocol::Command;
 use crate::protocol::CommandType;
+use crate::protocol::NoSpecificError;
 use crate::protocol::Request;
 use crate::protocol::Response;
 
@@ -32,6 +33,7 @@ pub enum DeviceInfo {}
 impl<'wire> Command<'wire> for DeviceInfo {
     type Req = DeviceInfoRequest;
     type Resp = DeviceInfoResponse<'wire>;
+    type Error = NoSpecificError;
 }
 
 wire_enum! {

--- a/src/protocol/device_uptime.rs
+++ b/src/protocol/device_uptime.rs
@@ -20,6 +20,7 @@ use crate::protocol::wire::FromWire;
 use crate::protocol::wire::ToWire;
 use crate::protocol::Command;
 use crate::protocol::CommandType;
+use crate::protocol::NoSpecificError;
 use crate::protocol::Request;
 use crate::protocol::Response;
 
@@ -41,6 +42,7 @@ pub enum DeviceUptime {}
 impl<'wire> Command<'wire> for DeviceUptime {
     type Req = DeviceUptimeRequest;
     type Resp = DeviceUptimeResponse;
+    type Error = NoSpecificError;
 }
 
 /// The [`DeviceUptime`] request.

--- a/src/protocol/error.rs
+++ b/src/protocol/error.rs
@@ -1,0 +1,337 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Error definitions for Cerberus messages.
+
+use core::convert::TryFrom;
+use core::convert::TryInto;
+
+use crate::crypto;
+use crate::io::ReadInt as _;
+use crate::io::ReadZero;
+use crate::io::Write;
+use crate::mem::Arena;
+use crate::mem::OutOfMemory;
+use crate::protocol::wire;
+use crate::protocol::wire::FromWire;
+use crate::protocol::wire::ToWire;
+use crate::protocol::CommandType;
+use crate::protocol::Response;
+use crate::session;
+
+#[cfg(doc)]
+use crate::protocol;
+
+/// An uninterpreted Cerberus Error.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct RawError {
+    /// What kind of error this is.
+    pub code: u8,
+    /// A fixed array of "extra data" that can come with an error code.
+    pub data: [u8; 4],
+}
+
+impl<'wire> FromWire<'wire> for RawError {
+    fn from_wire<R: ReadZero<'wire> + ?Sized, A: Arena>(
+        r: &mut R,
+        _: &'wire A,
+    ) -> Result<Self, wire::Error> {
+        let code = r.read_le()?;
+        let mut data = [0; 4];
+        r.read_bytes(&mut data)?;
+
+        Ok(Self { code, data })
+    }
+}
+
+impl ToWire for RawError {
+    fn to_wire<W: Write>(&self, mut w: W) -> Result<(), wire::Error> {
+        w.write_le(self.code)?;
+        w.write_bytes(&self.data[..])?;
+        Ok(())
+    }
+}
+
+/// An "empty" response, indicating only that a request was executed
+/// successfully.
+///
+/// At the Cerberus wire level, this is actually a [`RawError`] with code `0`.
+///
+/// This command corresponds to [`CommandType::Error`] and does not have a
+/// request counterpart.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct Ack;
+
+impl Response<'_> for Ack {
+    const TYPE: CommandType = CommandType::Error;
+}
+
+impl<'wire> FromWire<'wire> for Ack {
+    fn from_wire<R: ReadZero<'wire> + ?Sized, A: Arena>(
+        r: &mut R,
+        a: &'wire A,
+    ) -> Result<Self, wire::Error> {
+        RawError::from_wire(r, a)?.try_into()
+    }
+}
+
+impl ToWire for Ack {
+    fn to_wire<W: Write>(&self, w: W) -> Result<(), wire::Error> {
+        RawError::from(*self).to_wire(w)
+    }
+}
+
+impl From<Ack> for RawError {
+    fn from(_: Ack) -> RawError {
+        RawError {
+            code: 0,
+            data: [0; 4],
+        }
+    }
+}
+
+impl TryFrom<RawError> for Ack {
+    type Error = wire::Error;
+    fn try_from(e: RawError) -> Result<Ack, wire::Error> {
+        match e {
+            RawError {
+                code: 0,
+                data: [0, 0, 0, 0],
+            } => Ok(Ack),
+            _ => Err(wire::Error::OutOfRange),
+        }
+    }
+}
+
+/// A Cerberus error.
+///
+/// These errors can either be "generic", meaning they are not specific to a
+/// particular message type; specific to a particular message type, or unknown.
+///
+/// For the time being, Manticore uses the following wire format for its errors:
+/// - Errors that Cerberus specified are encoded as-is.
+/// - Manticore-defined generic errors are encoded as an `Unspecified` error
+///   where the first byte of the payload specifies which error it is.
+/// - Manticore-defined, message-specific errors are encoded as an `Unspecified`
+///   error with the first byte of the payload `0xff` and the second by specifying
+///   the error.
+/// - All other `Unspecified` errors are encoded as-is.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum Error<E = NoSpecificError> {
+    /// Indicates that the device is "busy", usually meaning that other
+    /// commands are being serviced.
+    Busy,
+
+    /// Indicates that resources were exhausted during processing of a
+    /// request. This can include memory exhaustion.
+    ///
+    /// This is a Manticore-specific error.
+    ResourceLimit,
+
+    /// Indicates that a request's structure was malformed.
+    ///
+    /// This is a Manticore-specific error.
+    Malformed,
+
+    /// Indicates that the request included an index (such as a certificate
+    /// slot, a PMR index, or a port) which was out of range.
+    ///
+    /// This is a Manticore-specific error.
+    OutOfRange,
+
+    /// Indicates that some kind of internal error occured; this likely
+    /// indicates a bug in the implementation.
+    ///
+    /// All `manticore::crypto` errors get folded into this error by default.
+    ///
+    /// This is a Manticore-specific error.
+    Internal,
+
+    /// An error specific to a particular message type, if there are any.
+    Specific(E),
+
+    /// Indicates an unspecified, vendor-defined error, which may include
+    /// extra unformatted data.
+    Unspecified([u8; 4]),
+
+    /// An error that Manticore does not understand.
+    Unknown(RawError),
+}
+
+impl<'wire, E: SpecificError> FromWire<'wire> for Error<E> {
+    fn from_wire<R: ReadZero<'wire> + ?Sized, A: Arena>(
+        r: &mut R,
+        a: &'wire A,
+    ) -> Result<Self, wire::Error> {
+        let error = RawError::from_wire(r, a)?;
+
+        match error {
+            RawError {
+                code: 3,
+                data: [0, 0, 0, 0],
+            } => Ok(Self::Busy),
+            RawError {
+                code: 4,
+                data: [b, 0, 0, 0],
+            } => match b {
+                1 => Ok(Self::ResourceLimit),
+                2 => Ok(Self::Malformed),
+                3 => Ok(Self::OutOfRange),
+                4 => Ok(Self::Internal),
+                _ => Err(wire::Error::OutOfRange),
+            },
+            RawError {
+                code: 4,
+                data: [0xff, code, 0, 0],
+            } => Ok(Self::Specific(E::from_raw(code)?)),
+            RawError { code: 4, data } => Ok(Self::Unspecified(data)),
+            _ => Ok(Self::Unknown(error)),
+        }
+    }
+}
+
+impl<E: SpecificError> ToWire for Error<E> {
+    fn to_wire<W: Write>(&self, w: W) -> Result<(), wire::Error> {
+        let raw = match self {
+            Self::Busy => RawError {
+                code: 3,
+                data: [0; 4],
+            },
+            Self::ResourceLimit => RawError {
+                code: 4,
+                data: [1, 0, 0, 0],
+            },
+            Self::Malformed => RawError {
+                code: 4,
+                data: [2, 0, 0, 0],
+            },
+            Self::OutOfRange => RawError {
+                code: 4,
+                data: [3, 0, 0, 0],
+            },
+            Self::Internal => RawError {
+                code: 4,
+                data: [4, 0, 0, 0],
+            },
+            Self::Specific(e) => RawError {
+                code: 4,
+                data: [0xff, e.to_raw()?, 0, 0],
+            },
+            Self::Unspecified(data) => RawError {
+                code: 4,
+                data: *data,
+            },
+            Self::Unknown(e) => *e,
+        };
+
+        raw.to_wire(w)
+    }
+}
+
+impl<E> From<OutOfMemory> for Error<E> {
+    fn from(_: OutOfMemory) -> Self {
+        Self::ResourceLimit
+    }
+}
+
+impl<E> From<crypto::csrng::Error> for Error<E> {
+    fn from(_: crypto::csrng::Error) -> Self {
+        Self::Internal
+    }
+}
+
+impl<E> From<crypto::hash::Error> for Error<E> {
+    fn from(_: crypto::hash::Error) -> Self {
+        Self::Internal
+    }
+}
+
+impl<E> From<crypto::sig::Error> for Error<E> {
+    fn from(_: crypto::sig::Error) -> Self {
+        Self::Internal
+    }
+}
+
+impl<E> From<session::Error> for Error<E> {
+    fn from(_: session::Error) -> Self {
+        Self::Internal
+    }
+}
+
+impl<E: SpecificError> From<E> for Error<E> {
+    fn from(e: E) -> Self {
+        Self::Specific(e)
+    }
+}
+
+/// A type that describes a message-specific error.
+///
+/// This trait is an implementation detail.
+#[doc(hidden)]
+pub trait SpecificError: Sized {
+    /// Converts an error into this error type, if it represents one.
+    fn from_raw(code: u8) -> Result<Self, wire::Error>;
+
+    /// Copies this error into an error code.
+    fn to_raw(&self) -> Result<u8, wire::Error>;
+}
+
+/// An empty [`SpecificError`], for use with messages without interesting error
+/// messages.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum NoSpecificError {}
+impl SpecificError for NoSpecificError {
+    fn from_raw(_: u8) -> Result<Self, wire::Error> {
+        Err(wire::Error::OutOfRange)
+    }
+
+    fn to_raw(&self) -> Result<u8, wire::Error> {
+        match *self {}
+    }
+}
+
+/// Helper for creating specific errors. Compare `wire_enum!`.
+macro_rules! specific_error {
+    (
+        $(#[$emeta:meta])*
+        $vis:vis enum $name:ident {$(
+            $(#[$vmeta:meta])*
+            $var:ident = $code:literal
+        ),* $(,)*}
+    ) => {
+        #[derive(Clone, Copy, PartialEq, Eq, Debug)]
+        #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+        $(#[$emeta])*
+        $vis enum $name {$(
+            $(#[$vmeta])*
+            $var,
+        )*}
+
+        impl $crate::protocol::SpecificError for $name {
+            fn from_raw(code: u8) -> Result<Self, $crate::protocol::wire::Error> {
+                match code {
+                    $($code => Ok(Self::$var),)*
+                    _ => Err($crate::protocol::wire::Error::OutOfRange),
+                }
+            }
+            fn to_raw(&self) -> Result<u8, $crate::protocol::wire::Error> {
+                match self {$(
+                    Self::$var => Ok($code),
+                )*}
+            }
+        }
+    };
+}
+
+specific_error! {
+    /// Errors specific to the [`protocol::Challenge`] and related messages.
+    pub enum ChallengeError {
+        /// The requested certificate chain does not exist.
+        UnknownChain = 0x00,
+    }
+}

--- a/src/protocol/firmware_version.rs
+++ b/src/protocol/firmware_version.rs
@@ -17,6 +17,7 @@ use crate::protocol::wire::FromWire;
 use crate::protocol::wire::ToWire;
 use crate::protocol::Command;
 use crate::protocol::CommandType;
+use crate::protocol::NoSpecificError;
 use crate::protocol::Request;
 use crate::protocol::Response;
 
@@ -38,6 +39,7 @@ pub enum FirmwareVersion {}
 impl<'wire> Command<'wire> for FirmwareVersion {
     type Req = FirmwareVersionRequest;
     type Resp = FirmwareVersionResponse<'wire>;
+    type Error = NoSpecificError;
 }
 
 /// The [`FirmwareVersion`] request.

--- a/src/protocol/get_cert.rs
+++ b/src/protocol/get_cert.rs
@@ -14,6 +14,7 @@ use crate::mem::ArenaExt as _;
 use crate::protocol::wire;
 use crate::protocol::wire::FromWire;
 use crate::protocol::wire::ToWire;
+use crate::protocol::ChallengeError;
 use crate::protocol::Command;
 use crate::protocol::CommandType;
 use crate::protocol::Request;
@@ -32,6 +33,7 @@ pub enum GetCert {}
 impl<'wire> Command<'wire> for GetCert {
     type Req = GetCertRequest;
     type Resp = GetCertResponse<'wire>;
+    type Error = ChallengeError;
 }
 
 /// The [`GetCert`] request.

--- a/src/protocol/get_digests.rs
+++ b/src/protocol/get_digests.rs
@@ -20,6 +20,7 @@ use crate::mem::ArenaExt as _;
 use crate::protocol::wire;
 use crate::protocol::wire::FromWire;
 use crate::protocol::wire::ToWire;
+use crate::protocol::ChallengeError;
 use crate::protocol::Command;
 use crate::protocol::CommandType;
 use crate::protocol::Request;
@@ -38,6 +39,7 @@ pub enum GetDigests {}
 impl<'wire> Command<'wire> for GetDigests {
     type Req = GetDigestsRequest;
     type Resp = GetDigestsResponse<'wire>;
+    type Error = ChallengeError;
 }
 
 wire_enum! {

--- a/src/protocol/get_host_state.rs
+++ b/src/protocol/get_host_state.rs
@@ -16,6 +16,7 @@ use crate::protocol::wire::FromWire;
 use crate::protocol::wire::ToWire;
 use crate::protocol::Command;
 use crate::protocol::CommandType;
+use crate::protocol::NoSpecificError;
 use crate::protocol::Request;
 use crate::protocol::Response;
 
@@ -32,6 +33,7 @@ pub enum GetHostState {}
 impl Command<'_> for GetHostState {
     type Req = GetHostStateRequest;
     type Resp = GetHostStateResponse;
+    type Error = NoSpecificError;
 }
 
 /// The [`GetHostState`] request.

--- a/src/protocol/key_exchange.rs
+++ b/src/protocol/key_exchange.rs
@@ -18,6 +18,7 @@ use crate::mem::Arena;
 use crate::protocol::wire;
 use crate::protocol::wire::FromWire;
 use crate::protocol::wire::ToWire;
+use crate::protocol::ChallengeError;
 use crate::protocol::Command;
 use crate::protocol::CommandType;
 use crate::protocol::Request;
@@ -41,6 +42,7 @@ pub enum KeyExchange {}
 impl<'wire> Command<'wire> for KeyExchange {
     type Req = KeyExchangeRequest<'wire>;
     type Resp = KeyExchangeResponse<'wire>;
+    type Error = ChallengeError;
 }
 
 wire_enum! {

--- a/src/protocol/request_counter.rs
+++ b/src/protocol/request_counter.rs
@@ -18,6 +18,7 @@ use crate::protocol::wire::FromWire;
 use crate::protocol::wire::ToWire;
 use crate::protocol::Command;
 use crate::protocol::CommandType;
+use crate::protocol::NoSpecificError;
 use crate::protocol::Request;
 use crate::protocol::Response;
 
@@ -34,6 +35,7 @@ pub enum RequestCounter {}
 impl<'wire> Command<'wire> for RequestCounter {
     type Req = RequestCounterRequest;
     type Resp = RequestCounterResponse;
+    type Error = NoSpecificError;
 }
 
 /// The [`RequestCounter`] request.

--- a/src/protocol/reset_counter.rs
+++ b/src/protocol/reset_counter.rs
@@ -17,6 +17,7 @@ use crate::protocol::wire::FromWire;
 use crate::protocol::wire::ToWire;
 use crate::protocol::Command;
 use crate::protocol::CommandType;
+use crate::protocol::NoSpecificError;
 use crate::protocol::Request;
 use crate::protocol::Response;
 
@@ -38,6 +39,7 @@ pub enum ResetCounter {}
 impl<'wire> Command<'wire> for ResetCounter {
     type Req = ResetCounterRequest;
     type Resp = ResetCounterResponse;
+    type Error = NoSpecificError;
 }
 
 wire_enum! {


### PR DESCRIPTION
What it says in the title: handlers now use proper errors instead of hand-rolling Cerberus errors.

Right now all the Manticore-specific errors use the "vendor specified" error format, but hopefully this PR can be used as a model for better error handling in Cerberus in the future.