### PR TITLE
[server] Parametrize the handler framework over header types

### DIFF
--- a/e2e/src/pa_rot.rs
+++ b/e2e/src/pa_rot.rs
@@ -20,6 +20,7 @@ use manticore::cert::CertFormat;
 use manticore::crypto::ring;
 use manticore::mem::Arena;
 use manticore::mem::BumpArena;
+use manticore::net;
 use manticore::protocol;
 use manticore::protocol::capabilities;
 use manticore::protocol::device_id::DeviceIdentifier;
@@ -202,7 +203,10 @@ impl Virtual {
         &self,
         req: Cmd::Req,
         arena: &'a dyn Arena,
-    ) -> Result<Result<Cmd::Resp, protocol::Error>, server::Error>
+    ) -> Result<
+        Result<Cmd::Resp, protocol::Error>,
+        server::Error<net::CerberusHeader>,
+    >
     where
         Cmd: protocol::Command<'a>,
         Cmd::Req: protocol::Request<'a, CommandType = protocol::CommandType>,

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -48,6 +48,23 @@ impl From<io::Error> for Error {
     }
 }
 
+/// A header type, which represents a protocol over the wire.
+pub trait Header: Copy {
+    /// The command type enum associated with this header.
+    type CommandType;
+
+    /// Returns the [`Self::CommandType`] contained within `self`.
+    fn command(&self) -> Self::CommandType;
+
+    /// Constructs a new header for replying to a request that used this header,
+    /// but with the given `command_type` in the response.
+    fn reply_with(&self, command: Self::CommandType) -> Self;
+
+    /// Constructs a new header for replying to a request that used this header,
+    /// indicating that the reply contains an error.
+    fn reply_with_error(&self) -> Self;
+}
+
 /// An abstract Cerberus message header.
 ///
 /// This type records fields extracted out of an incoming Cerberus message's
@@ -58,7 +75,22 @@ impl From<io::Error> for Error {
 /// implementation.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct Header {
+pub struct CerberusHeader {
     /// The [`CommandType`] for a request.
     pub command: CommandType,
+}
+
+impl Header for CerberusHeader {
+    type CommandType = CommandType;
+
+    fn command(&self) -> CommandType {
+        self.command
+    }
+    fn reply_with(&self, command: CommandType) -> Self {
+        Self { command }
+    }
+
+    fn reply_with_error(&self) -> Self {
+        self.reply_with(CommandType::Error)
+    }
 }

--- a/src/server/pa_rot.rs
+++ b/src/server/pa_rot.rs
@@ -16,6 +16,7 @@ use crate::hardware;
 use crate::mem::Arena;
 use crate::mem::ArenaExt as _;
 use crate::net;
+use crate::net::CerberusHeader;
 use crate::protocol;
 use crate::protocol::capabilities;
 use crate::protocol::device_id;
@@ -100,12 +101,12 @@ impl<'a> PaRot<'a> {
     /// Process a single incoming request.
     pub fn process_request<'req>(
         &mut self,
-        host_port: &mut dyn net::host::HostPort<'req>,
+        host_port: &mut dyn net::host::HostPort<'req, CerberusHeader>,
         arena: &'req dyn Arena,
-    ) -> Result<(), Error> {
+    ) -> Result<(), Error<CerberusHeader>> {
         // Style note: when defining a new handler, if it is more than a
         // handful of lines long, define it out-of-line instead.
-        let result = Handler::<&mut Self>::new()
+        let result = Handler::<&mut Self, CerberusHeader>::new()
             .handle::<protocol::FirmwareVersion, _>(|ctx| {
                 ctx.server.handle_fw_version(&ctx.req)
             })


### PR DESCRIPTION
This change makes HostPort and the handler framework built on top of it
parametric over the Header type; there is now a net::CerberusHeader
specifically for Cerberus, which will be followed up with a
net::SpdmHeader, allowing us to reuse most of Manticore's infrastructure
for implementing SPDM.

Note: this PR is based on #137; only the lastest commit is relevant.