### PR TITLE
[mem] Switch all uses of Arena to be trait objects

### DIFF
--- a/e2e/src/pa_rot.rs
+++ b/e2e/src/pa_rot.rs
@@ -198,16 +198,15 @@ impl Virtual {
     /// Sends `req` to this virtal RoT, using Cerberus-over-TCP.
     ///
     /// Blocks until a response comes back.
-    pub fn send_local<'a, Cmd, A>(
+    pub fn send_local<'a, Cmd>(
         &self,
         req: Cmd::Req,
-        arena: &'a A,
+        arena: &'a dyn Arena,
     ) -> Result<Result<Cmd::Resp, protocol::Error>, server::Error>
     where
         Cmd: protocol::Command<'a>,
-        A: Arena,
     {
-        tcp::send_local::<Cmd, A>(self.port, req, arena)
+        tcp::send_local::<Cmd>(self.port, req, arena)
     }
 }
 

--- a/e2e/src/tcp.rs
+++ b/e2e/src/tcp.rs
@@ -43,14 +43,13 @@ use manticore::server;
 /// Cerberus-over-TCP.
 ///
 /// Blocks until a response comes back.
-pub fn send_local<'a, Cmd, A>(
+pub fn send_local<'a, Cmd>(
     port: u16,
     req: Cmd::Req,
-    arena: &'a A,
+    arena: &'a dyn Arena,
 ) -> Result<Result<Cmd::Resp, protocol::Error>, server::Error>
 where
     Cmd: Command<'a>,
-    A: Arena,
 {
     log::info!("connecting to 127.0.0.1:{}", port);
     let mut conn = TcpStream::connect(("127.0.0.1", port)).map_err(|e| {

--- a/e2e/src/tests/challenge.rs
+++ b/e2e/src/tests/challenge.rs
@@ -46,7 +46,7 @@ fn challenge() {
 
     let mut arena = BumpArena::new(vec![0; 1024]);
     let resp = virt
-        .send_local::<GetDigests, _>(
+        .send_local::<GetDigests>(
             GetDigestsRequest {
                 slot: 0,
                 key_exchange: KeyExchangeAlgo::Ecdh,
@@ -71,7 +71,7 @@ fn challenge() {
         let mut cert = Vec::new();
         loop {
             let resp = virt
-                .send_local::<GetCert, _>(
+                .send_local::<GetCert>(
                     GetCertRequest {
                         slot: 0,
                         cert_number: i as u8,
@@ -115,10 +115,7 @@ fn challenge() {
         slot: 0,
         nonce: &[99; 32],
     };
-    let resp = virt
-        .send_local::<Challenge, _>(req, &arena)
-        .unwrap()
-        .unwrap();
+    let resp = virt.send_local::<Challenge>(req, &arena).unwrap().unwrap();
     log::info!("got nonce: {:?}", resp.tbs.nonce);
 
     // Compute the expected signee: our challenge, plus the response's
@@ -149,7 +146,7 @@ fn challenge() {
         pk_req,
     };
     let resp = virt
-        .send_local::<KeyExchange, _>(req, &arena)
+        .send_local::<KeyExchange>(req, &arena)
         .unwrap()
         .unwrap();
     let (pk_resp, pk_sig, alias_hmac) = match resp {

--- a/e2e/src/tests/device_queries.rs
+++ b/e2e/src/tests/device_queries.rs
@@ -18,7 +18,7 @@ fn firmware_version() {
     });
 
     let arena = BumpArena::new([0; 64]);
-    let resp = virt.send_local::<FirmwareVersion, _>(
+    let resp = virt.send_local::<FirmwareVersion>(
         FirmwareVersionRequest { index: 0 },
         &arena,
     );
@@ -40,7 +40,7 @@ fn vendor_firmware_version() {
     });
 
     let arena = BumpArena::new([0; 64]);
-    let resp = virt.send_local::<FirmwareVersion, _>(
+    let resp = virt.send_local::<FirmwareVersion>(
         FirmwareVersionRequest { index: 1 },
         &arena,
     );
@@ -62,7 +62,7 @@ fn vendor_firmware_version_out_of_range() {
     });
 
     let arena = BumpArena::new([0; 64]);
-    let resp = virt.send_local::<FirmwareVersion, _>(
+    let resp = virt.send_local::<FirmwareVersion>(
         FirmwareVersionRequest { index: 2 },
         &arena,
     );
@@ -85,7 +85,7 @@ fn device_id() {
     });
 
     let arena = BumpArena::new([0; 64]);
-    let resp = virt.send_local::<DeviceId, _>(DeviceIdRequest {}, &arena);
+    let resp = virt.send_local::<DeviceId>(DeviceIdRequest {}, &arena);
     assert_eq!(
         resp.unwrap().unwrap().id,
         DeviceIdentifier {

--- a/src/crypto/hash.rs
+++ b/src/crypto/hash.rs
@@ -48,7 +48,7 @@ impl Algo {
 
     /// Allocates sufficient storage from `arena` to hold a hash of this type.
     #[inline]
-    pub fn alloc(self, arena: &impl Arena) -> Result<&mut [u8], OutOfMemory> {
+    pub fn alloc(self, arena: &dyn Arena) -> Result<&mut [u8], OutOfMemory> {
         arena.alloc_slice(self.bytes())
     }
 }

--- a/src/protocol/capabilities.rs
+++ b/src/protocol/capabilities.rs
@@ -273,9 +273,9 @@ mod consts {
 }
 
 impl<'wire> FromWire<'wire> for Capabilities {
-    fn from_wire<R: ReadZero<'wire> + ?Sized, A: Arena>(
+    fn from_wire<R: ReadZero<'wire> + ?Sized>(
         r: &mut R,
-        _: &'wire A,
+        _: &'wire dyn Arena,
     ) -> Result<Capabilities, wire::Error> {
         use consts::*;
         let max_message_size = r.read_le::<u16>()?;

--- a/src/protocol/challenge.rs
+++ b/src/protocol/challenge.rs
@@ -137,9 +137,9 @@ impl ChallengeResponseTbs<'_> {
 }
 
 impl<'wire> FromWire<'wire> for ChallengeResponseTbs<'wire> {
-    fn from_wire<R: ReadZero<'wire> + ?Sized, A: Arena>(
+    fn from_wire<R: ReadZero<'wire> + ?Sized>(
         r: &mut R,
-        arena: &'wire A,
+        arena: &'wire dyn Arena,
     ) -> Result<Self, wire::Error> {
         let slot = r.read_le()?;
         let slot_mask = r.read_le()?;

--- a/src/protocol/device_id.rs
+++ b/src/protocol/device_id.rs
@@ -74,9 +74,9 @@ pub struct DeviceIdentifier {
 }
 
 impl<'wire> FromWire<'wire> for DeviceIdentifier {
-    fn from_wire<R: ReadZero<'wire> + ?Sized, A: Arena>(
+    fn from_wire<R: ReadZero<'wire> + ?Sized>(
         r: &mut R,
-        _: &'wire A,
+        _: &'wire dyn Arena,
     ) -> Result<Self, wire::Error> {
         let vendor_id = r.read_le::<u16>()?;
         let device_id = r.read_le::<u16>()?;

--- a/src/protocol/error.rs
+++ b/src/protocol/error.rs
@@ -34,9 +34,9 @@ pub struct RawError {
 }
 
 impl<'wire> FromWire<'wire> for RawError {
-    fn from_wire<R: ReadZero<'wire> + ?Sized, A: Arena>(
+    fn from_wire<R: ReadZero<'wire> + ?Sized>(
         r: &mut R,
-        _: &'wire A,
+        _: &'wire dyn Arena,
     ) -> Result<Self, wire::Error> {
         let code = r.read_le()?;
         let mut data = [0; 4];
@@ -70,9 +70,9 @@ impl Response<'_> for Ack {
 }
 
 impl<'wire> FromWire<'wire> for Ack {
-    fn from_wire<R: ReadZero<'wire> + ?Sized, A: Arena>(
+    fn from_wire<R: ReadZero<'wire> + ?Sized>(
         r: &mut R,
-        a: &'wire A,
+        a: &'wire dyn Arena,
     ) -> Result<Self, wire::Error> {
         RawError::from_wire(r, a)?.try_into()
     }
@@ -163,9 +163,9 @@ pub enum Error<E = NoSpecificError> {
 }
 
 impl<'wire, E: SpecificError> FromWire<'wire> for Error<E> {
-    fn from_wire<R: ReadZero<'wire> + ?Sized, A: Arena>(
+    fn from_wire<R: ReadZero<'wire> + ?Sized>(
         r: &mut R,
-        a: &'wire A,
+        a: &'wire dyn Arena,
     ) -> Result<Self, wire::Error> {
         let error = RawError::from_wire(r, a)?;
 

--- a/src/protocol/template.rs
+++ b/src/protocol/template.rs
@@ -99,9 +99,9 @@ macro_rules! protocol_struct {
             }
 
             impl<'wire> FromWire<'wire> for Req<'wire> {
-                fn from_wire<R: ReadZero<'wire> + ?Sized, A: Arena>(
+                fn from_wire<R: ReadZero<'wire> + ?Sized>(
                     $r_req: &mut R,
-                    $a_req: &'wire A,
+                    $a_req: &'wire dyn Arena,
                 ) -> Result<Self, wire::Error> {
                     $req_from
                 }
@@ -149,9 +149,9 @@ macro_rules! protocol_struct {
                 }
 
                 impl<'wire> FromWire<'wire> for Resp<'wire> {
-                    fn from_wire<R: ReadZero<'wire> + ?Sized, A: Arena>(
+                    fn from_wire<R: ReadZero<'wire> + ?Sized>(
                         $r_rsp: &mut R,
-                        $a_rsp: &'wire A,
+                        $a_rsp: &'wire dyn Arena,
                     ) -> Result<Self, wire::Error> {
                         $rsp_from
                     }

--- a/src/protocol/wire.rs
+++ b/src/protocol/wire.rs
@@ -25,9 +25,9 @@ use crate::mem::OutOfMemory;
 /// buffer of lifetime `'wire`.
 pub trait FromWire<'wire>: Sized {
     /// Deserializes a `Self` w of `r`.
-    fn from_wire<R: ReadZero<'wire> + ?Sized, A: Arena>(
+    fn from_wire<R: ReadZero<'wire> + ?Sized>(
         r: &mut R,
-        arena: &'wire A,
+        arena: &'wire dyn Arena,
     ) -> Result<Self, Error>;
 }
 
@@ -111,9 +111,9 @@ where
     E: WireEnum,
     E::Wire: LeInt,
 {
-    fn from_wire<R: ReadZero<'wire> + ?Sized, A: Arena>(
+    fn from_wire<R: ReadZero<'wire> + ?Sized>(
         r: &mut R,
-        _: &'wire A,
+        _: &'wire dyn Arena,
     ) -> Result<Self, Error> {
         let wire = <Self as WireEnum>::Wire::read_from(r)?;
         Self::from_wire_value(wire).ok_or(Error::OutOfRange)

--- a/src/server/pa_rot.rs
+++ b/src/server/pa_rot.rs
@@ -98,14 +98,14 @@ impl<'a> PaRot<'a> {
     }
 
     /// Process a single incoming request.
-    pub fn process_request<'req, A: Arena>(
+    pub fn process_request<'req>(
         &mut self,
         host_port: &mut dyn net::host::HostPort<'req>,
-        arena: &'req A,
+        arena: &'req dyn Arena,
     ) -> Result<(), Error> {
         // Style note: when defining a new handler, if it is more than a
         // handful of lines long, define it out-of-line instead.
-        let result = Handler::<&mut Self, A>::new()
+        let result = Handler::<&mut Self>::new()
             .handle::<protocol::FirmwareVersion, _>(|ctx| {
                 ctx.server.handle_fw_version(&ctx.req)
             })
@@ -230,7 +230,7 @@ impl<'a> PaRot<'a> {
 
     fn handle_digests<'req>(
         &mut self,
-        arena: &'req impl Arena,
+        arena: &'req dyn Arena,
         req: &protocol::get_digests::GetDigestsRequest,
     ) -> Result<
         protocol::get_digests::GetDigestsResponse<'req>,
@@ -288,7 +288,7 @@ impl<'a> PaRot<'a> {
 
     fn handle_challenge<'req>(
         &'req mut self,
-        arena: &'req impl Arena,
+        arena: &'req dyn Arena,
         req: &protocol::challenge::ChallengeRequest,
         req_buf: &[u8],
     ) -> Result<
@@ -329,7 +329,7 @@ impl<'a> PaRot<'a> {
 
     fn handle_key_xchg<'req>(
         &mut self,
-        arena: &'req impl Arena,
+        arena: &'req dyn Arena,
         req: &protocol::key_exchange::KeyExchangeRequest,
     ) -> Result<
         protocol::key_exchange::KeyExchangeResponse<'req>,


### PR DESCRIPTION
This change is similar in spirit to 82ef871a, which trades off using a
dyn for cutting down on type parameters. Similar reasoning applies here;
in practice, calling into an arena is quite rare, and we were already
forced into dyn Arenas to make other, more complex traits be
object-safe, too.

Signed-off-by: Miguel Young de la Sota <mcyoung@google.com>