### PR TITLE
[protocol] Clean up and reorganize the `manticore::protocol` traits.

### DIFF
--- a/e2e/src/pa_rot.rs
+++ b/e2e/src/pa_rot.rs
@@ -204,7 +204,7 @@ impl Virtual {
         req: Cmd::Req,
         arena: &'a dyn Arena,
     ) -> Result<
-        Result<Cmd::Resp, protocol::Error>,
+        Result<Cmd::Resp, protocol::Error<'a, Cmd>>,
         server::Error<net::CerberusHeader>,
     >
     where

--- a/e2e/src/pa_rot.rs
+++ b/e2e/src/pa_rot.rs
@@ -209,8 +209,8 @@ impl Virtual {
     >
     where
         Cmd: protocol::Command<'a>,
-        Cmd::Req: protocol::Request<'a, CommandType = protocol::CommandType>,
-        Cmd::Resp: protocol::Response<'a, CommandType = protocol::CommandType>,
+        Cmd::Req: protocol::Message<'a, CommandType = protocol::CommandType>,
+        Cmd::Resp: protocol::Message<'a, CommandType = protocol::CommandType>,
     {
         tcp::send_local::<Cmd>(self.port, req, arena)
     }

--- a/e2e/src/pa_rot.rs
+++ b/e2e/src/pa_rot.rs
@@ -208,9 +208,7 @@ impl Virtual {
         server::Error<net::CerberusHeader>,
     >
     where
-        Cmd: protocol::Command<'a>,
-        Cmd::Req: protocol::Message<'a, CommandType = protocol::CommandType>,
-        Cmd::Resp: protocol::Message<'a, CommandType = protocol::CommandType>,
+        Cmd: protocol::Command<'a, CommandType = protocol::CommandType>,
     {
         tcp::send_local::<Cmd>(self.port, req, arena)
     }

--- a/e2e/src/tcp.rs
+++ b/e2e/src/tcp.rs
@@ -42,19 +42,14 @@ use manticore::server;
 /// Cerberus-over-TCP.
 ///
 /// Blocks until a response comes back.
-pub fn send_local<'a, Cmd>(
+pub fn send_local<'a, Cmd: Command<'a, CommandType = CommandType>>(
     port: u16,
     req: Cmd::Req,
     arena: &'a dyn Arena,
 ) -> Result<
     Result<Cmd::Resp, protocol::Error>,
     server::Error<net::CerberusHeader>,
->
-where
-    Cmd: Command<'a>,
-    Cmd::Req: Message<'a, CommandType = CommandType>,
-    Cmd::Resp: Message<'a, CommandType = CommandType>,
-{
+> {
     log::info!("connecting to 127.0.0.1:{}", port);
     let mut conn = TcpStream::connect(("127.0.0.1", port)).map_err(|e| {
         log::error!("{}", e);

--- a/e2e/src/tcp.rs
+++ b/e2e/src/tcp.rs
@@ -47,7 +47,7 @@ pub fn send_local<'a, Cmd: Command<'a, CommandType = CommandType>>(
     req: Cmd::Req,
     arena: &'a dyn Arena,
 ) -> Result<
-    Result<Cmd::Resp, protocol::Error>,
+    Result<Cmd::Resp, protocol::Error<'a, Cmd>>,
     server::Error<net::CerberusHeader>,
 > {
     log::info!("connecting to 127.0.0.1:{}", port);
@@ -93,7 +93,7 @@ pub fn send_local<'a, Cmd: Command<'a, CommandType = CommandType>>(
         log::info!("deserializing {}", type_name::<Cmd::Resp>());
         Ok(Ok(FromWire::from_wire(&mut r, arena)?))
     } else if header.command == CommandType::Error {
-        log::info!("deserializing {}", type_name::<protocol::Error>());
+        log::info!("deserializing {}", type_name::<protocol::Error<'a, Cmd>>());
         Ok(Err(FromWire::from_wire(&mut r, arena)?))
     } else {
         Err(net::Error::BadHeader.into())

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -13,8 +13,9 @@
 //! device over a SPI line, it should tie up all the necessary implementation
 //! details into a [`HostPort`] implementation.
 
-use crate::io;
+use core::fmt::Debug;
 
+use crate::io;
 use crate::protocol::CommandType;
 
 pub mod device;
@@ -51,7 +52,7 @@ impl From<io::Error> for Error {
 /// A header type, which represents a protocol over the wire.
 pub trait Header: Copy {
     /// The command type enum associated with this header.
-    type CommandType;
+    type CommandType: Copy + Debug + Eq;
 
     /// Returns the [`Self::CommandType`] contained within `self`.
     fn command(&self) -> Self::CommandType;

--- a/src/protocol/cerberus/challenge.rs
+++ b/src/protocol/cerberus/challenge.rs
@@ -13,10 +13,10 @@ use crate::io::ReadInt as _;
 use crate::io::ReadZero;
 use crate::io::Write;
 use crate::mem::Arena;
+use crate::protocol::error::ChallengeError;
 use crate::protocol::wire;
 use crate::protocol::wire::FromWire;
 use crate::protocol::wire::ToWire;
-use crate::protocol::ChallengeError;
 use crate::protocol::CommandType;
 
 protocol_struct! {

--- a/src/protocol/cerberus/get_cert.rs
+++ b/src/protocol/cerberus/get_cert.rs
@@ -8,7 +8,7 @@
 
 use crate::io::ReadInt as _;
 use crate::mem::ArenaExt as _;
-use crate::protocol::ChallengeError;
+use crate::protocol::error::ChallengeError;
 use crate::protocol::CommandType;
 
 protocol_struct! {

--- a/src/protocol/cerberus/get_digests.rs
+++ b/src/protocol/cerberus/get_digests.rs
@@ -14,7 +14,7 @@ use zerocopy::AsBytes as _;
 use crate::crypto::hash;
 use crate::io::ReadInt as _;
 use crate::mem::ArenaExt as _;
-use crate::protocol::ChallengeError;
+use crate::protocol::error::ChallengeError;
 use crate::protocol::CommandType;
 
 protocol_struct! {

--- a/src/protocol/cerberus/key_exchange.rs
+++ b/src/protocol/cerberus/key_exchange.rs
@@ -11,7 +11,7 @@ use core::convert::TryInto as _;
 use crate::crypto::hash;
 use crate::io::read::ReadZeroExt as _;
 use crate::io::ReadInt as _;
-use crate::protocol::ChallengeError;
+use crate::protocol::error::ChallengeError;
 use crate::protocol::CommandType;
 
 protocol_struct! {

--- a/src/protocol/error.rs
+++ b/src/protocol/error.rs
@@ -120,6 +120,10 @@ impl TryFrom<RawError> for Ack {
 ///   error with the first byte of the payload `0xff` and the second by specifying
 ///   the error.
 /// - All other `Unspecified` errors are encoded as-is.
+///
+/// This type will typically be accessed via the [`protocol::Error`] alias.
+///
+/// [`protocol::Error`]: super::Error
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Error<E = NoSpecificError> {
@@ -313,7 +317,7 @@ macro_rules! specific_error {
             $var,
         )*}
 
-        impl $crate::protocol::SpecificError for $name {
+        impl $crate::protocol::error::SpecificError for $name {
             fn from_raw(code: u8) -> Result<Self, $crate::protocol::wire::Error> {
                 match code {
                     $($code => Ok(Self::$var),)*

--- a/src/protocol/error.rs
+++ b/src/protocol/error.rs
@@ -17,7 +17,7 @@ use crate::protocol::wire;
 use crate::protocol::wire::FromWire;
 use crate::protocol::wire::ToWire;
 use crate::protocol::CommandType;
-use crate::protocol::Response;
+use crate::protocol::Message;
 use crate::session;
 
 #[cfg(doc)]
@@ -65,7 +65,7 @@ impl ToWire for RawError {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Ack;
 
-impl Response<'_> for Ack {
+impl Message<'_> for Ack {
     type CommandType = CommandType;
     const TYPE: CommandType = CommandType::Error;
 }

--- a/src/protocol/error.rs
+++ b/src/protocol/error.rs
@@ -126,7 +126,7 @@ impl TryFrom<RawError> for Ack {
 /// [`protocol::Error`]: super::Error
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub enum Error<E = NoSpecificError> {
+pub enum Error<E> {
     /// Indicates that the device is "busy", usually meaning that other
     /// commands are being serviced.
     Busy,

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -53,8 +53,9 @@ pub mod template;
 pub mod wire;
 
 #[macro_use]
-mod error;
-pub use error::*;
+pub mod error;
+#[cfg(doc)]
+use error::{Ack, NoSpecificError};
 
 mod cerberus;
 pub use cerberus::*;
@@ -71,6 +72,11 @@ pub mod spdm;
 /// This trait is not implemented by any of the request or response types, but
 /// is intead implemented by uninhabited types that represent pairs of requests
 /// and responses, for use in generic programming.
+///
+/// This trait is often used via a bound like `C: for<'a> Command<'a>`, allowing
+/// its members to be used as a sort of faux-generalized associated type. However,
+/// the current syntax for going from `C` to `Req` is somewhat painful, so the
+/// aliases [`Req`], [`Resp`], and [`Error`] are provided to alleviate this.
 pub trait Command<'wire> {
     /// The enum of command types this `Command` draws its types from.
     type CommandType: Copy + Debug + Eq;
@@ -86,6 +92,21 @@ pub trait Command<'wire> {
     /// In general, this will just be [`NoSpecificError`].
     type Error: error::SpecificError;
 }
+
+/// Extracts the request type with lifetime `'a` from `C: for<'a> Command<'a>`.
+///
+/// See [`Command`].
+pub type Req<'a, C> = <C as Command<'a>>::Req;
+
+/// Extracts the response type with lifetime `'a` from `C: for<'a> Command<'a>`.
+///
+/// See [`Command`].
+pub type Resp<'a, C> = <C as Command<'a>>::Resp;
+
+/// Extracts the error type with lifetime `'a` from `C: for<'a> Command<'a>`.
+///
+/// See [`Command`].
+pub type Error<'a, C> = error::Error<<C as Command<'a>>::Error>;
 
 /// A Manticore message type, which makes up part of a `Command`.
 pub trait Message<'wire>: wire::FromWire<'wire> + wire::ToWire {

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -74,10 +74,10 @@ pub mod spdm;
 /// and responses, for use in generic programming.
 pub trait Command<'wire> {
     /// The unique request type for this `Command`.
-    type Req: Request<'wire>;
+    type Req: Message<'wire>;
     /// The response type for this `Command`, which will either be unique or
     /// [`Ack`].
-    type Resp: Response<'wire>;
+    type Resp: Message<'wire>;
 
     /// The message-specific errors for this `Command`.
     ///
@@ -85,24 +85,11 @@ pub trait Command<'wire> {
     type Error: error::SpecificError;
 }
 
-/// A Manticore request.
-///
-/// See [`Command`].
-pub trait Request<'wire>: wire::FromWire<'wire> + wire::ToWire {
-    /// The enum of command types this `Request` draws its type from.
+/// A Manticore message type, which makes up part of a `Command`.
+pub trait Message<'wire>: wire::FromWire<'wire> + wire::ToWire {
+    /// The enum of command types this `Message` draws its type from.
     type CommandType;
 
     /// The unique [`CommandType`] for this `Request`.
-    const TYPE: Self::CommandType;
-}
-
-/// A Manticore response.
-///
-/// See [`Command`].
-pub trait Response<'wire>: wire::FromWire<'wire> + wire::ToWire {
-    /// The enum of command types this `Response` draws its type from.
-    type CommandType;
-
-    /// The unique [`CommandType`] for this `Response`.
     const TYPE: Self::CommandType;
 }

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -38,8 +38,7 @@
 //! Also, unlike Cerberus, Manticore does not require that a session be
 //! spoken over MCTP, and, as such, does not use the same header as Cerberus.
 
-// This is required due to the make_fuzz_safe! macro.
-#![allow(unused_parens)]
+use core::fmt::Debug;
 
 #[macro_use]
 mod macros;
@@ -73,11 +72,14 @@ pub mod spdm;
 /// is intead implemented by uninhabited types that represent pairs of requests
 /// and responses, for use in generic programming.
 pub trait Command<'wire> {
+    /// The enum of command types this `Command` draws its types from.
+    type CommandType: Copy + Debug + Eq;
+
     /// The unique request type for this `Command`.
-    type Req: Message<'wire>;
+    type Req: Message<'wire, CommandType = Self::CommandType>;
     /// The response type for this `Command`, which will either be unique or
     /// [`Ack`].
-    type Resp: Message<'wire>;
+    type Resp: Message<'wire, CommandType = Self::CommandType>;
 
     /// The message-specific errors for this `Command`.
     ///
@@ -88,7 +90,7 @@ pub trait Command<'wire> {
 /// A Manticore message type, which makes up part of a `Command`.
 pub trait Message<'wire>: wire::FromWire<'wire> + wire::ToWire {
     /// The enum of command types this `Message` draws its type from.
-    type CommandType;
+    type CommandType: Copy + Debug + Eq;
 
     /// The unique [`CommandType`] for this `Request`.
     const TYPE: Self::CommandType;

--- a/src/protocol/template.rs
+++ b/src/protocol/template.rs
@@ -43,7 +43,7 @@ macro_rules! protocol_struct {
             use $crate::protocol::wire::FromWire;
             use $crate::protocol::wire::ToWire;
             use $crate::protocol::Command;
-            use $crate::protocol::NoSpecificError;
+            use $crate::protocol::error::NoSpecificError;
             use $crate::protocol::Message;
 
             #[cfg(feature = "arbitrary-derive")]

--- a/src/protocol/template.rs
+++ b/src/protocol/template.rs
@@ -67,6 +67,8 @@ macro_rules! protocol_struct {
             protocol_struct!(@internal if_nonempty ($($req_lt)?) {
                 derive_borrowed! {
                     #[doc = "The [`" $Command "`] request."]
+                    #[doc = ""]
+                    #[doc = "Prefer to refer to this type as `Req<" $Command ">`."]
                     #[derive(Clone, Copy, PartialEq, Eq, Debug)]
                     #[cfg_attr(feature = "serde", derive(serde::Serialize))]
                     $(#[$req_meta])*
@@ -83,6 +85,8 @@ macro_rules! protocol_struct {
             } else {
                 derive_borrowed! {
                     #[doc = "The [`" $Command "`] request."]
+                    #[doc = ""]
+                    #[doc = "Prefer to refer to this type as `Req<" $Command ">`."]
                     #[derive(Clone, Copy, PartialEq, Eq, Debug)]
                     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
                     #[cfg_attr(feature = "arbitrary-derive", derive(Arbitrary))]
@@ -118,6 +122,8 @@ macro_rules! protocol_struct {
                 protocol_struct!(@internal if_nonempty ($($rsp_lt)?) {
                     derive_borrowed! {
                         #[doc = "The [`" $Command "`] response."]
+                        #[doc = ""]
+                        #[doc = "Prefer to refer to this type as `Resp<" $Command ">`."]
                         #[derive(Clone, Copy, PartialEq, Eq, Debug)]
                         #[cfg_attr(feature = "serde", derive(serde::Serialize))]
                         $(#[$rsp_meta])*
@@ -134,6 +140,8 @@ macro_rules! protocol_struct {
                 } else {
                     derive_borrowed! {
                         #[doc = "The [`" $Command "`] response."]
+                        #[doc = ""]
+                        #[doc = "Prefer to refer to this type as `Resp<" $Command ">`."]
                         #[derive(Clone, Copy, PartialEq, Eq, Debug)]
                         #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
                         #[cfg_attr(feature = "arbitrary-derive", derive(Arbitrary))]

--- a/src/protocol/template.rs
+++ b/src/protocol/template.rs
@@ -44,8 +44,7 @@ macro_rules! protocol_struct {
             use $crate::protocol::wire::ToWire;
             use $crate::protocol::Command;
             use $crate::protocol::NoSpecificError;
-            use $crate::protocol::Request;
-            use $crate::protocol::Response;
+            use $crate::protocol::Message;
 
             #[cfg(feature = "arbitrary-derive")]
             use libfuzzer_sys::arbitrary::{self, Arbitrary};
@@ -94,7 +93,7 @@ macro_rules! protocol_struct {
                 type Req<'wire> = [<$Command Request>];
             });
 
-            impl<'wire> Request<'wire> for Req<'wire> {
+            impl<'wire> Message<'wire> for Req<'wire> {
                 type CommandType = $CommandType;
                 const TYPE: $CommandType = $CommandType::$TYPE;
             }
@@ -145,7 +144,7 @@ macro_rules! protocol_struct {
                     type Resp<'wire> = [<$Command Response>];
                 });
 
-                impl<'wire> Response<'wire> for Resp<'wire> {
+                impl<'wire> Message<'wire> for Resp<'wire> {
                     type CommandType = $CommandType;
                     const TYPE: $CommandType = $CommandType::$TYPE;
                 }

--- a/src/protocol/template.rs
+++ b/src/protocol/template.rs
@@ -54,6 +54,7 @@ macro_rules! protocol_struct {
             pub enum $Command {}
 
             impl<'wire> Command<'wire> for $Command {
+                type CommandType = $CommandType;
                 type Req = Req<'wire>;
                 type Resp = Resp<'wire>;
                 type Error = protocol_struct!(@internal if_nonempty ($($Error)?) {

--- a/tool/src/message.rs
+++ b/tool/src/message.rs
@@ -40,11 +40,11 @@ macro_rules! proto_match {
     (($cmd:expr, $is_req:expr, $mty:ident, $expr:expr) in {$($t:ty,)*}) => {
         match ($cmd, $is_req) {
             $(
-                (<<$t as Command<'static>>::Req as protocol::Request<'static>>::TYPE, true) => {
+                (<<$t as Command<'static>>::Req as protocol::Message<'static>>::TYPE, true) => {
                     type $mty = <$t as Command<'static>>::Req;
                     $expr
                 }
-                (<<$t as Command<'static>>::Resp as protocol::Response<'static>>::TYPE, false) => {
+                (<<$t as Command<'static>>::Resp as protocol::Message<'static>>::TYPE, false) => {
                     type $mty = <$t as Command<'static>>::Resp;
                     $expr
                 }

--- a/tool/src/message.rs
+++ b/tool/src/message.rs
@@ -19,6 +19,9 @@ use manticore::protocol::wire::FromWire;
 use manticore::protocol::wire::ToWire;
 use manticore::protocol::Command;
 use manticore::protocol::CommandType;
+use manticore::protocol::Message as _;
+use manticore::protocol::Req;
+use manticore::protocol::Resp;
 
 macro_rules! proto_match {
     (($cmd:expr, $is_req:expr) in |$mty:ident: type| $expr:expr) => {
@@ -40,11 +43,11 @@ macro_rules! proto_match {
     (($cmd:expr, $is_req:expr, $mty:ident, $expr:expr) in {$($t:ty,)*}) => {
         match ($cmd, $is_req) {
             $(
-                (<<$t as Command<'static>>::Req as protocol::Message<'static>>::TYPE, true) => {
+                (Req::<'static, $t>::TYPE, true) => {
                     type $mty = <$t as Command<'static>>::Req;
                     $expr
                 }
-                (<<$t as Command<'static>>::Resp as protocol::Message<'static>>::TYPE, false) => {
+                (Resp::<'static, $t>::TYPE, false) => {
                     type $mty = <$t as Command<'static>>::Resp;
                     $expr
                 }


### PR DESCRIPTION
Changes include:
- Merger of `Request` and `Response` into `Message`.
- New `Command::CommandType` associated type to simplify several `where` clauses.
- Move `ReqOf`, `RespOf`, and `ErrOf` into `protocol`'s public API.
- Use all of the above to simplify message-manipulation code.