### PR TITLE
[protocol] Start switching to `enumflags2`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ members = [".", "e2e", "tool", "testutil"]
 
 [dependencies]
 arrayvec = { version = "0.7", default_features = false }
-bitflags = "1.2.1"
 byteorder = { version = "1.3.4", default_features = false }
 enumflags2 = "0.7.1"
 extend = "1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ members = [".", "e2e", "tool", "testutil"]
 arrayvec = { version = "0.7", default_features = false }
 bitflags = "1.2.1"
 byteorder = { version = "1.3.4", default_features = false }
+enumflags2 = "0.7.1"
 extend = "1.1"
 paste = "1.0"
 untrusted = "0.7"

--- a/e2e/src/pa_rot.rs
+++ b/e2e/src/pa_rot.rs
@@ -221,7 +221,7 @@ pub fn serve(opts: Options) -> ! {
         max_message_size: opts.max_message_size,
         max_packet_size: opts.max_packet_size,
         mode: capabilities::RotMode::Platform,
-        roles: capabilities::BusRole::HOST,
+        roles: capabilities::BusRole::Host.into(),
     };
 
     let timeouts = capabilities::Timeouts {

--- a/src/crypto/ring/sig.rs
+++ b/src/crypto/ring/sig.rs
@@ -8,6 +8,8 @@
 
 use core::convert::TryInto as _;
 
+use enumflags2::BitFlags;
+
 use crate::crypto::ring::ecdsa;
 use crate::crypto::ring::rsa;
 use crate::crypto::sig;
@@ -40,8 +42,8 @@ impl sig::Ciphers for Ciphers {
             has_ecc: true,
             has_rsa: true,
 
-            ecc_strength: EccKeyStrength::BITS_256,
-            rsa_strength: RsaKeyStrength::all(),
+            ecc_strength: EccKeyStrength::Bits256.into(),
+            rsa_strength: BitFlags::<RsaKeyStrength>::all(),
             ..*caps
         };
     }

--- a/src/manifest/mod.rs
+++ b/src/manifest/mod.rs
@@ -153,41 +153,6 @@ impl<S: WireEnum<Wire = u8>> WireEnum for ElementType<S> {
             _ => S::from_wire_value(wire).map(Self::Specific),
         }
     }
-
-    fn name(self) -> &'static str {
-        macro_rules! names {
-            (vendor: [$($n:tt,)*]) => { match self {
-                Self::PlatformId => "PlatformId",
-                Self::Specific(s) => s.name(),
-                $(Self::Vendor($n) => concat!("Vendor(", stringify!($n), ")"),)*
-                Self::Vendor(_) => "Vendor(_)",
-            }}
-        }
-
-        names!(vendor: [
-            0xe0, 0xe1, 0xe2, 0xe3, 0xe4, 0xe5, 0xe6, 0xe7,
-            0xe8, 0xe9, 0xea, 0xeb, 0xec, 0xed, 0xee, 0xef,
-            0xf0, 0xf1, 0xf2, 0xf3, 0xf4, 0xf5, 0xf6, 0xf7,
-            0xf8, 0xf9, 0xfa, 0xfb, 0xfc, 0xfd, 0xfe,
-        ])
-    }
-
-    fn from_name(name: &str) -> Option<Self> {
-        macro_rules! names {
-            (vendor: [$($n:tt,)*]) => { match name {
-                "PlatformId" => Some(Self::PlatformId),
-                $(concat!("Vendor(", stringify!($n), ")") => Some(Self::Vendor($n)),)*
-                _ => S::from_name(name).map(Self::Specific),
-            }}
-        }
-
-        names!(vendor: [
-            0xe0, 0xe1, 0xe2, 0xe3, 0xe4, 0xe5, 0xe6, 0xe7,
-            0xe8, 0xe9, 0xea, 0xeb, 0xec, 0xed, 0xee, 0xef,
-            0xf0, 0xf1, 0xf2, 0xf3, 0xf4, 0xf5, 0xf6, 0xf7,
-            0xf8, 0xf9, 0xfa, 0xfb, 0xfc, 0xfd, 0xfe,
-        ])
-    }
 }
 
 impl<S> From<S> for ElementType<S> {

--- a/src/protocol/cerberus/capabilities.rs
+++ b/src/protocol/cerberus/capabilities.rs
@@ -10,7 +10,8 @@
 
 use core::time::Duration;
 
-use bitflags::bitflags;
+use enumflags2::bitflags;
+use enumflags2::BitFlags;
 
 use crate::io::bit_buf::BitBuf;
 use crate::io::ReadInt as _;
@@ -23,8 +24,6 @@ use crate::protocol::wire::ToWire;
 use crate::protocol::wire::WireEnum;
 use crate::protocol::CommandType;
 
-#[cfg(feature = "arbitrary-derive")]
-use libfuzzer_sys::arbitrary::{self, Arbitrary};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
@@ -90,8 +89,8 @@ protocol_struct! {
 
 wire_enum! {
     /// A "mode" for a Cerberus RoT: "active" or "platform".
-    #[cfg_attr(feature = "arbitrary-derive", derive(Arbitrary))]
     #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+    #[cfg_attr(feature = "arbitrary-derive", derive(Arbitrary))]
     pub enum RotMode: u8 {
         /// Represents an "AC-RoT" or "Active Root of Trust", an RoT chip which
         /// protects some kind of peripheral hardware.
@@ -103,75 +102,73 @@ wire_enum! {
     }
 }
 
-bitflags! {
-    /// The role of this device on a shared bus.
-    ///
-    /// (Cerberus refers to these capabilities as master/slave.)
-    #[cfg_attr(feature = "arbitrary-derive", derive(Arbitrary))]
-    #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-    pub struct BusRole: u8 {
-        /// This device can act as a "host".
-        const HOST = 0b01;
-        /// This device can act as a "target".
-        const TARGET = 0b10;
-    }
+/// The role of this device on a shared bus.
+#[bitflags]
+#[repr(u8)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub enum BusRole {
+    /// This device can act as a "host".
+    Host = 0b01,
+    /// This device can act as a "target".
+    Target = 0b10,
 }
 
-bitflags! {
-    /// Represents a "security capability".
-    ///
-    /// I.e, this enum describes different security primitives the device might
-    /// support.
-    #[cfg_attr(feature = "arbitrary-derive", derive(Arbitrary))]
-    #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-    pub struct Security: u8 {
-        /// This device has hash and key derivation capabilities.
-        const HASH_AND_KDF = 0b001;
-        /// This device has authentication capabilities, using some kind of
-        /// PKI mechanism.
-        const AUTHENTICATION = 0b010;
-        /// This device can send and recieve confidential messages over a
-        /// secured channel, using AES.
-        const CONFIDENTIALITY = 0b100;
-    }
+/// Represents a "security capability".
+///
+/// I.e, this enum describes different security primitives the device might
+/// support.
+#[bitflags]
+#[repr(u8)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub enum Security {
+    /// This device has hash and key derivation capabilities.
+    HashAndKdf = 0b001,
+    /// This device has authentication capabilities, using some kind of
+    /// PKI mechanism.
+    Authentication = 0b010,
+    /// This device can send and recieve confidential messages over a
+    /// secured channel, using AES.
+    Confidentiality = 0b100,
 }
 
-bitflags! {
-    /// Represents a supported elliptic curve cryptography key strength.
-    #[cfg_attr(feature = "arbitrary-derive", derive(Arbitrary))]
-    #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-    pub struct EccKeyStrength: u8 {
-        /// A key strength of 160 bits.
-        const BITS_160 = 0b001;
-        /// A key strength of 256 bits.
-        const BITS_256 = 0b010;
-    }
+/// Represents a supported elliptic curve cryptography key strength.
+#[bitflags]
+#[repr(u8)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub enum EccKeyStrength {
+    /// A key strength of 160 bits.
+    Bits160 = 0b001,
+    /// A key strength of 256 bits.
+    Bits256 = 0b010,
 }
 
-bitflags! {
-    /// Represents a supported RSA key strength.
-    #[cfg_attr(feature = "arbitrary-derive", derive(Arbitrary))]
-    #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-    pub struct RsaKeyStrength: u8 {
-        /// A key strength of 2048 bits.
-        const BITS_2048 = 0b001;
-        /// A key strength of 3072 bits.
-        const BITS_3072 = 0b010;
-        /// A key strength of 4096 bits.
-        const BITS_4096 = 0b100;
-    }
+/// Represents a supported RSA key strength.
+#[bitflags]
+#[repr(u8)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub enum RsaKeyStrength {
+    /// A key strength of 2048 bits.
+    Bits2048 = 0b001,
+    /// A key strength of 3072 bits.
+    Bits3072 = 0b010,
+    /// A key strength of 4096 bits.
+    Bits4096 = 0b100,
 }
 
-bitflags! {
-    /// Represents a supported AES key strength.
-    #[cfg_attr(feature = "arbitrary-derive", derive(Arbitrary))]
-    #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-    pub struct AesKeyStrength: u8 {
-        /// A key strength of 128 bits.
-        const BITS_128 = 0b001;
-        /// A key strength of 256 bits.
-        const BITS_256 = 0b010;
-    }
+/// Represents a supported AES key strength.
+#[bitflags]
+#[repr(u8)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub enum AesKeyStrength {
+    /// A key strength of 128 bits.
+    Bits128 = 0b001,
+    /// A key strength of 256 bits.
+    Bits256 = 0b010,
 }
 
 /// Network-related capabilities for a device.
@@ -179,7 +176,6 @@ bitflags! {
 /// A value of this type needs to be provided to `manticore` by an integration,
 /// so that it can faithfully report it during capabilities negotiation.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
-#[cfg_attr(feature = "arbitrary-derive", derive(Arbitrary))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Networking {
     /// The maximum message size this device can buffer, in bytes.
@@ -202,12 +198,12 @@ pub struct Networking {
     /// The type of RoT this device is.
     pub mode: RotMode,
     /// Valid "bus roles" of this device: is a host, a target, or both?
-    pub roles: BusRole,
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde::bitflags"))]
+    pub roles: BitFlags<BusRole>,
 }
 
 /// Cryptographic device capabilities.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
-#[cfg_attr(feature = "arbitrary-derive", derive(Arbitrary))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Crypto {
     /// Whether this device supports ECDSA.
@@ -220,11 +216,14 @@ pub struct Crypto {
     pub has_aes: bool,
 
     /// ECC key strengths supported by this device.
-    pub ecc_strength: EccKeyStrength,
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde::bitflags"))]
+    pub ecc_strength: BitFlags<EccKeyStrength>,
     /// RSA key strengths supported by this device.
-    pub rsa_strength: RsaKeyStrength,
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde::bitflags"))]
+    pub rsa_strength: BitFlags<RsaKeyStrength>,
     /// AES key strengths supported by this device.
-    pub aes_strength: AesKeyStrength,
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde::bitflags"))]
+    pub aes_strength: BitFlags<AesKeyStrength>,
 }
 
 /// A description of device capabilities.
@@ -235,7 +234,6 @@ pub struct Crypto {
 /// Some fields in this struct may apear unused or redundant. This struct is
 /// meant to be a strict reflection of the wire format specified by Cerberus.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
-#[cfg_attr(feature = "arbitrary-derive", derive(Arbitrary))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Capabilities {
     /// Integration-provided information on the device's networking
@@ -243,7 +241,8 @@ pub struct Capabilities {
     pub networking: Networking,
 
     /// Security primitives supported by this device.
-    pub security: Security,
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde::bitflags"))]
+    pub security: BitFlags<Security>,
     /// Whether this primitive "supports PFMs".
     ///
     /// The meaning of this field is unspecified by Cerberus.
@@ -291,8 +290,8 @@ impl<'wire> FromWire<'wire> for Capabilities {
 
         let mode = RotMode::from_wire_value(mode_bits)
             .ok_or(wire::Error::OutOfRange)?;
-        let roles =
-            BusRole::from_bits(bus_bits).ok_or(wire::Error::OutOfRange)?;
+        let roles = BitFlags::<BusRole>::from_bits(bus_bits)
+            .map_err(|_| wire::Error::OutOfRange)?;
         let networking = Networking {
             max_message_size,
             max_packet_size,
@@ -300,8 +299,8 @@ impl<'wire> FromWire<'wire> for Capabilities {
             roles,
         };
 
-        let security = Security::from_bits(security_bits)
-            .ok_or(wire::Error::OutOfRange)?;
+        let security = BitFlags::<Security>::from_bits(security_bits)
+            .map_err(|_| wire::Error::OutOfRange)?;
 
         // The sixth byte consists of five reserved bits, and the PFM, policy,
         // and firmware protection bits.
@@ -319,10 +318,10 @@ impl<'wire> FromWire<'wire> for Capabilities {
         let ecc_bits = byte_seven.read_bits(ECC_SIZE)?;
         let rsa_bits = byte_seven.read_bits(RSA_SIZE)?;
 
-        let rsa_strength = RsaKeyStrength::from_bits(rsa_bits)
-            .ok_or(wire::Error::OutOfRange)?;
-        let ecc_strength = EccKeyStrength::from_bits(ecc_bits)
-            .ok_or(wire::Error::OutOfRange)?;
+        let rsa_strength = BitFlags::<RsaKeyStrength>::from_bits(rsa_bits)
+            .map_err(|_| wire::Error::OutOfRange)?;
+        let ecc_strength = BitFlags::<EccKeyStrength>::from_bits(ecc_bits)
+            .map_err(|_| wire::Error::OutOfRange)?;
 
         // The eighth byte consists of the aes strength, four reserved bits,
         // and the ecc bit.
@@ -331,8 +330,8 @@ impl<'wire> FromWire<'wire> for Capabilities {
         let _ = byte_eight.read_bits(4)?;
         let aes_bits = byte_eight.read_bits(AES_SIZE)?;
 
-        let aes_strength = AesKeyStrength::from_bits(aes_bits)
-            .ok_or(wire::Error::OutOfRange)?;
+        let aes_strength = BitFlags::<AesKeyStrength>::from_bits(aes_bits)
+            .map_err(|_| wire::Error::OutOfRange)?;
 
         Ok(Capabilities {
             networking,
@@ -395,6 +394,39 @@ impl ToWire for Capabilities {
     }
 }
 
+#[cfg(feature = "arbitrary-derive")]
+use {
+    crate::protocol::arbitrary_bitflags,
+    libfuzzer_sys::arbitrary::{self, Arbitrary, Unstructured},
+};
+
+#[cfg(feature = "arbitrary-derive")]
+impl Arbitrary for Capabilities {
+    fn arbitrary(u: &mut Unstructured) -> arbitrary::Result<Self> {
+        Ok(Self {
+            networking: Networking {
+                max_message_size: u.arbitrary()?,
+                max_packet_size: u.arbitrary()?,
+                mode: u.arbitrary()?,
+                roles: arbitrary_bitflags(u)?,
+            },
+            security: arbitrary_bitflags(u)?,
+            has_pfm_support: u.arbitrary()?,
+            has_policy_support: u.arbitrary()?,
+            has_firmware_protection: u.arbitrary()?,
+            crypto: Crypto {
+                has_ecdsa: u.arbitrary()?,
+                has_ecc: u.arbitrary()?,
+                has_rsa: u.arbitrary()?,
+                has_aes: u.arbitrary()?,
+                ecc_strength: arbitrary_bitflags(u)?,
+                rsa_strength: arbitrary_bitflags(u)?,
+                aes_strength: arbitrary_bitflags(u)?,
+            },
+        })
+    }
+}
+
 /// Timeout "capabilities", that is, how long a client should expect a device
 /// to take to respond to a request before it decides that the device is
 /// unreachable.
@@ -438,9 +470,9 @@ mod test {
                         "max_message_size": 256,
                         "max_packet_size": 128,
                         "mode": "Platform",
-                        "roles": { "bits": 3 }
+                        "roles": ["Host", "Target"]
                     },
-                    "security": { "bits": 3 },
+                    "security": ["HashAndKdf", "Authentication"],
                     "has_pfm_support": true,
                     "has_policy_support": false,
                     "has_firmware_protection": false,
@@ -449,9 +481,9 @@ mod test {
                         "has_ecc": false,
                         "has_rsa": true,
                         "has_aes": false,
-                        "ecc_strength": { "bits": 0 },
-                        "rsa_strength": { "bits": 1 },
-                        "aes_strength": { "bits": 3 }
+                        "ecc_strength": [],
+                        "rsa_strength": ["Bits2048"],
+                        "aes_strength": ["Bits128", "Bits256"]
                     }
                 }
             }"#,
@@ -461,9 +493,9 @@ mod test {
                         max_message_size: 0x100,
                         max_packet_size: 0x80,
                         mode: RotMode::Platform,
-                        roles: BusRole::HOST | BusRole::TARGET,
+                        roles: BusRole::Host | BusRole::Target,
                     },
-                    security: Security::HASH_AND_KDF | Security::AUTHENTICATION,
+                    security: Security::HashAndKdf | Security::Authentication,
                     has_pfm_support: true,
                     has_policy_support: false,
                     has_firmware_protection: false,
@@ -472,9 +504,9 @@ mod test {
                         has_ecc: false,
                         has_rsa: true,
                         has_aes: false,
-                        ecc_strength: EccKeyStrength::empty(),
-                        rsa_strength: RsaKeyStrength::BITS_2048,
-                        aes_strength: AesKeyStrength::BITS_128 | AesKeyStrength::BITS_256,
+                        ecc_strength: BitFlags::<EccKeyStrength>::empty(),
+                        rsa_strength: RsaKeyStrength::Bits2048.into(),
+                        aes_strength: AesKeyStrength::Bits128 | AesKeyStrength::Bits256,
                     },
                 },
             },
@@ -496,9 +528,9 @@ mod test {
                         "max_message_size": 256,
                         "max_packet_size": 128,
                         "mode": "Platform",
-                        "roles": { "bits": 3 }
+                        "roles": ["Host", "Target"]
                     },
-                    "security": { "bits": 3 },
+                    "security": ["HashAndKdf", "Authentication"],
                     "has_pfm_support": true,
                     "has_policy_support": false,
                     "has_firmware_protection": false,
@@ -507,9 +539,9 @@ mod test {
                         "has_ecc": false,
                         "has_rsa": true,
                         "has_aes": false,
-                        "ecc_strength": { "bits": 0 },
-                        "rsa_strength": { "bits": 1 },
-                        "aes_strength": { "bits": 3 }
+                        "ecc_strength": [],
+                        "rsa_strength": ["Bits2048"],
+                        "aes_strength": ["Bits128", "Bits256"]
                     }
                 },
                 "timeouts": {
@@ -523,9 +555,9 @@ mod test {
                         max_message_size: 0x100,
                         max_packet_size: 0x80,
                         mode: RotMode::Platform,
-                        roles: BusRole::HOST | BusRole::TARGET,
+                        roles: BusRole::Host | BusRole::Target,
                     },
-                    security: Security::HASH_AND_KDF | Security::AUTHENTICATION,
+                    security: Security::HashAndKdf | Security::Authentication,
                     has_pfm_support: true,
                     has_policy_support: false,
                     has_firmware_protection: false,
@@ -534,9 +566,9 @@ mod test {
                         has_ecc: false,
                         has_rsa: true,
                         has_aes: false,
-                        ecc_strength: EccKeyStrength::empty(),
-                        rsa_strength: RsaKeyStrength::BITS_2048,
-                        aes_strength: AesKeyStrength::BITS_128 | AesKeyStrength::BITS_256,
+                        ecc_strength: BitFlags::<EccKeyStrength>::empty(),
+                        rsa_strength: RsaKeyStrength::Bits2048.into(),
+                        aes_strength: AesKeyStrength::Bits128 | AesKeyStrength::Bits256,
                     },
                 },
                 timeouts: Timeouts {

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -116,3 +116,15 @@ pub trait Message<'wire>: wire::FromWire<'wire> + wire::ToWire {
     /// The unique [`CommandType`] for this `Request`.
     const TYPE: Self::CommandType;
 }
+
+/// Helper for fuzzing bitflags.
+#[cfg(feature = "arbitrary-derive")]
+fn arbitrary_bitflags<B>(
+    u: &mut libfuzzer_sys::arbitrary::Unstructured,
+) -> libfuzzer_sys::arbitrary::Result<enumflags2::BitFlags<B>>
+where
+    B: enumflags2::BitFlag,
+    B::Numeric: libfuzzer_sys::arbitrary::Arbitrary,
+{
+    Ok(enumflags2::BitFlags::from_bits_truncate(u.arbitrary()?))
+}

--- a/src/protocol/spdm/get_caps.rs
+++ b/src/protocol/spdm/get_caps.rs
@@ -9,7 +9,8 @@
 use core::mem;
 use core::time::Duration;
 
-use bitflags::bitflags;
+use enumflags2::bitflags;
+use enumflags2::BitFlags;
 
 use crate::io::ReadInt as _;
 use crate::protocol::spdm;
@@ -20,25 +21,29 @@ protocol_struct! {
     type GetCaps;
     const TYPE: CommandType = GetCaps;
 
+    // NOTE: Because BitFlags does not implement Arbitrary, we're forced to
+    // skip using the derives, which is what this attribute achieves.
+    #![fuzz_derives_if = any()]
     struct Request {
         /// The timeout for operations involving cryptoraphy.
         pub crypto_timeout: Duration,
         /// The advertised capabilities.
-        pub caps: Capabilities,
+        #[cfg_attr(feature = "serde", serde(with = "crate::serde::bitflags"))]
+        pub caps: BitFlags<Caps>,
         /// The maximum packet size, in bytes.
         pub max_packet_size: u32,
         /// The maximum message size, in bytes.
         pub max_message_size: u32,
     }
 
-    fn Request::from_wire(r, _) {
+    fn Request::from_wire(r, a) {
         spdm::expect_zeros(r, 3)?;
 
         let ct_exp = r.read_le::<u8>()?;
         let crypto_timeout = Duration::from_micros(1u64 << ct_exp);
         spdm::expect_zeros(r, 2)?;
 
-        let caps = Capabilities::from_bits_truncate(r.read_le()?);
+        let caps = BitFlags::<Caps>::from_wire(r, a)?;
 
         let max_packet_size = r.read_le::<u32>()?;
         let max_message_size = r.read_le::<u32>()?;
@@ -58,7 +63,7 @@ protocol_struct! {
 
         spdm::write_zeros(&mut w, 2)?;
 
-        w.write_le(self.caps.bits())?;
+        self.caps.to_wire(&mut w)?;
         w.write_le(self.max_packet_size)?;
         w.write_le(self.max_message_size)?;
         Ok(())
@@ -66,25 +71,27 @@ protocol_struct! {
 
     // Ideally this would be a typedef of Request, but the macro currently doesn't
     // cleanly support that.
+    #![fuzz_derives_if = any()]
     struct Response {
         /// The timeout for operations involving cryptoraphy.
         pub crypto_timeout: Duration,
         /// The advertised capabilities.
-        pub caps: Capabilities,
+        #[cfg_attr(feature = "serde", serde(with = "crate::serde::bitflags"))]
+        pub caps: BitFlags<Caps>,
         /// The maximum packet size, in bytes.
         pub max_packet_size: u32,
         /// The maximum message size, in bytes.
         pub max_message_size: u32,
     }
 
-    fn Response::from_wire(r, _) {
+    fn Response::from_wire(r, a) {
         spdm::expect_zeros(r, 3)?;
 
         let ct_exp = r.read_le::<u8>()?;
         let crypto_timeout = Duration::from_micros(1u64 << ct_exp);
         spdm::expect_zeros(r, 2)?;
 
-        let caps = Capabilities::from_bits_truncate(r.read_le()?);
+        let caps = BitFlags::<Caps>::from_wire(r, a)?;
 
         let max_packet_size = r.read_le::<u32>()?;
         let max_message_size = r.read_le::<u32>()?;
@@ -104,7 +111,7 @@ protocol_struct! {
 
         spdm::write_zeros(&mut w, 2)?;
 
-        w.write_le(self.caps.bits())?;
+        self.caps.to_wire(&mut w)?;
         w.write_le(self.max_packet_size)?;
         w.write_le(self.max_message_size)?;
         Ok(())
@@ -112,66 +119,107 @@ protocol_struct! {
 }
 
 #[cfg(feature = "arbitrary-derive")]
-use libfuzzer_sys::arbitrary::{self, Arbitrary};
+use {
+    crate::protocol::arbitrary_bitflags,
+    libfuzzer_sys::arbitrary::{self, Arbitrary, Unstructured},
+};
 
-bitflags! {
-    /// SPDM protocol capability flags.
-    #[cfg_attr(feature = "arbitrary-derive", derive(Arbitrary))]
-    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-    pub struct Capabilities: u32 {
-        /// Whether negotiation information can be cached past a reset.
-        const CACHE = 1 << 0;
-        /// Whether certificates are supported.
-        const CERTS = 1 << 1;
-        /// Whether challenges are supported.
-        const CHALLENGE = 1 << 2;
-        /// Whether unsigned measurements are supported.
-        const UNSIGNED_MEASUREMENTS = 1 << 3;
-        /// Whether signed measurements are supported.
-        const SIGNED_MEASUREMENTS = 1 << 4;
-        /// Whether measurements will be recomputed on reset.
-        const FRESH_MEASUREMENTS = 1 << 5;
-        /// Whether sessions will be encrypted.
-        const SESSION_ENCRYPTION = 1 << 6;
-        /// Whether sessions will be authenticated with MACs.
-        const SESSION_AUTH = 1 << 7;
-        /// Whether mutual authentication is supported.
-        const MUTUAL_AUTH = 1 << 8;
-        /// Whether key exchange is supported.
-        const KEY_EXCHANGE = 1 << 9;
-        /// Whether pre-shared keys without context are supported.
-        const PSK_WITHOUT_CONTEXT = 1 << 10;
-        /// Whether pre-shared keys with context are supported.
-        const PSK_WITH_CONTEXT = 1 << 11;
-        /// Whether heartbeat messages are supported.
-        const HEARTBEAT = 1 << 13;
-        /// Whether mid-session key updates are supported.
-        const KEY_UPDATE = 1 << 14;
-        /// Whether messages other than those needed to set up a session can
-        /// be sent in the clear; this is set when *only* the handshake can be
-        /// sent in the clear.
-        const HANDSHAKE_IN_THE_CLEAR = 1 << 15;
-        /// Whether the requester's public key was provisioned to the device.
-        const PUB_KEY_PROVISIONED = 1 << 16;
-        /// Whether chunked messages are supported.
-        const CHUNKING = 1 << 17;
-        /// Whether the alias certificate model is supported.
-        const ALIAS_CERT = 1 << 18;
+#[cfg(feature = "arbitrary-derive")]
+impl Arbitrary for GetCapsRequest {
+    fn arbitrary(u: &mut Unstructured) -> arbitrary::Result<Self> {
+        Ok(Self {
+            crypto_timeout: u.arbitrary()?,
+            caps: arbitrary_bitflags(u)?,
+            max_packet_size: u.arbitrary()?,
+            max_message_size: u.arbitrary()?,
+        })
+    }
 
+    fn size_hint(_depth: usize) -> (usize, Option<usize>) {
+        let size = mem::size_of::<Duration>()
+            + mem::size_of::<BitFlags<Caps>>()
+            + mem::size_of::<u32>() * 2;
+        (size, Some(size))
     }
 }
 
-impl Capabilities {
+#[cfg(feature = "arbitrary-derive")]
+impl Arbitrary for GetCapsResponse {
+    fn arbitrary(u: &mut Unstructured) -> arbitrary::Result<Self> {
+        Ok(Self {
+            crypto_timeout: u.arbitrary()?,
+            caps: arbitrary_bitflags(u)?,
+            max_packet_size: u.arbitrary()?,
+            max_message_size: u.arbitrary()?,
+        })
+    }
+
+    fn size_hint(_depth: usize) -> (usize, Option<usize>) {
+        let size = mem::size_of::<Duration>()
+            + mem::size_of::<BitFlags<Caps>>()
+            + mem::size_of::<u32>() * 2;
+        (size, Some(size))
+    }
+}
+
+/// SPDM protocol capability flags.
+#[bitflags]
+#[repr(u32)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "arbitrary-derive", derive(Arbitrary))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum Caps {
+    /// Whether negotiation information can be cached past a reset.
+    Cache = 1 << 0,
+    /// Whether certificates are supported.
+    Certs = 1 << 1,
+    /// Whether challenges are supported.
+    Challenge = 1 << 2,
+    /// Whether unsigned measurements are supported.
+    UnsignedMeasurements = 1 << 3,
+    /// Whether signed measurements are supported.
+    SignedMeasurements = 1 << 4,
+    /// Whether measurements will be recomputed on reset.
+    FreshMeasurements = 1 << 5,
+    /// Whether sessions will be encrypted.
+    SessionEncryption = 1 << 6,
+    /// Whether sessions will be authenticated with MACs.
+    SessionAuth = 1 << 7,
+    /// Whether mutual authentication is supported.
+    MutualAuth = 1 << 8,
+    /// Whether key exchange is supported.
+    KeyExchange = 1 << 9,
+    /// Whether pre-shared keys without context are supported.
+    PskWithoutContext = 1 << 10,
+    /// Whether pre-shared keys with context are supported.
+    PskWithContext = 1 << 11,
+    /// Whether heartbeat messages are supported.
+    Heartbeat = 1 << 13,
+    /// Whether mid-session key updates are supported.
+    KeyUpdate = 1 << 14,
+    /// Whether messages other than those needed to set up a session can
+    /// be sent in the clear, this is set when *only* the handshake can be
+    /// sent in the clear.
+    HandshakeInTheClear = 1 << 15,
+    /// Whether the requester's public key was provisioned to the device.
+    PubKeyProvisioned = 1 << 16,
+    /// Whether chunked messages are supported.
+    Chunking = 1 << 17,
+    /// Whether the alias certificate model is supported.
+    AliasCert = 1 << 18,
+}
+
+impl Caps {
     /// Returns the set of capabilities a Manticore-based SPDM server will negotiate.
-    pub fn manticore() -> Self {
-        Self::CERTS
-            | Self::CHALLENGE
-            | Self::SIGNED_MEASUREMENTS
-            | Self::FRESH_MEASUREMENTS
-            | Self::SESSION_ENCRYPTION
-            | Self::KEY_EXCHANGE
-            | Self::HEARTBEAT
-            | Self::ALIAS_CERT
+    pub fn manticore() -> enumflags2::BitFlags<Self> {
+        Self::Certs
+            | Self::Challenge
+            | Self::SignedMeasurements
+            | Self::FreshMeasurements
+            | Self::SessionEncryption
+            | Self::KeyExchange
+            | Self::Heartbeat
+            | Self::AliasCert
     }
 }
 
@@ -190,13 +238,22 @@ mod test {
             ],
             json: r#"{
                 "crypto_timeout": { "nanos": 4096000, "secs": 0 },
-                "caps": { "bits": 270966 },
+                "caps": [
+                    "Certs",
+                    "Challenge",
+                    "SignedMeasurements",
+                    "FreshMeasurements",
+                    "SessionEncryption",
+                    "KeyExchange",
+                    "Heartbeat",
+                    "AliasCert"
+                ],
                 "max_packet_size": 256,
                 "max_message_size": 1024
             }"#,
             value: GetCapsRequest {
                 crypto_timeout: Duration::from_micros(4096),
-                caps: Capabilities::manticore(),
+                caps: Caps::manticore(),
                 max_packet_size: 256,
                 max_message_size: 1024,
             },
@@ -211,13 +268,22 @@ mod test {
             ],
             json: r#"{
                 "crypto_timeout": { "nanos": 4096000, "secs": 0 },
-                "caps": { "bits": 270966 },
+                "caps": [
+                    "Certs",
+                    "Challenge",
+                    "SignedMeasurements",
+                    "FreshMeasurements",
+                    "SessionEncryption",
+                    "KeyExchange",
+                    "Heartbeat",
+                    "AliasCert"
+                ],
                 "max_packet_size": 256,
                 "max_message_size": 1024
             }"#,
             value: GetCapsResponse {
                 crypto_timeout: Duration::from_micros(4096),
-                caps: Capabilities::manticore(),
+                caps: Caps::manticore(),
                 max_packet_size: 256,
                 max_message_size: 1024,
             },

--- a/src/protocol/template.rs
+++ b/src/protocol/template.rs
@@ -13,6 +13,7 @@ macro_rules! protocol_struct {
 
         const TYPE: $CommandType:ty = $TYPE:ident;
 
+        $(#![fuzz_derives_if = $($req_fuzz_condition:tt)*])?
         $(#[$req_meta:meta])*
         $(#[@static($sreq_meta:meta)])*
         $req_kw:ident Request $(<$req_lt:lifetime>)? {
@@ -24,6 +25,7 @@ macro_rules! protocol_struct {
         fn Request::to_wire(&$self_req:tt, $w_req:tt) $req_to:block
 
         $(
+            $(#![fuzz_derives_if = $($rsp_fuzz_condition:tt)*])?
             $(#[$rsp_meta:meta])*
             $(#[@static($srsp_meta:meta)])*
             $rsp_kw:ident Response $(<$rsp_lt:lifetime>)? {
@@ -77,7 +79,7 @@ macro_rules! protocol_struct {
                     #[@static(
                         derive(Clone, PartialEq, Eq, Debug),
                         cfg_attr(feature = "serde", derive(serde::Deserialize)),
-                        cfg_attr(feature = "arbitrary-derive", derive(Arbitrary)),
+                        cfg_attr(all($($($req_fuzz_condition)*,)? feature = "arbitrary-derive"), derive(Arbitrary)),
                     )]
                     $(#[@static($sreq_meta)])*
                     pub $req_kw [<$Command Request>] $(<$req_lt>)? {
@@ -92,7 +94,7 @@ macro_rules! protocol_struct {
                     #[doc = "Prefer to refer to this type as `Req<" $Command ">`."]
                     #[derive(Clone, Copy, PartialEq, Eq, Debug)]
                     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-                    #[cfg_attr(feature = "arbitrary-derive", derive(Arbitrary))]
+                    #[cfg_attr(all($($($req_fuzz_condition)*,)? feature = "arbitrary-derive"), derive(Arbitrary))]
                     $(#[$req_meta])*
                     $(#[@static($sreq_meta)])*
                     pub $req_kw [<$Command Request>] {
@@ -134,7 +136,7 @@ macro_rules! protocol_struct {
                         #[@static(
                             derive(Clone, PartialEq, Eq, Debug),
                             cfg_attr(feature = "serde", derive(serde::Deserialize)),
-                            cfg_attr(feature = "arbitrary-derive", derive(Arbitrary)),
+                            cfg_attr(all($($($rsp_fuzz_condition)*,)? feature = "arbitrary-derive"), derive(Arbitrary)),
                         )]
                         $(#[@static($srsp_meta)])*
                         pub $rsp_kw [<$Command Response>] $(<$rsp_lt>)? {
@@ -149,7 +151,7 @@ macro_rules! protocol_struct {
                         #[doc = "Prefer to refer to this type as `Resp<" $Command ">`."]
                         #[derive(Clone, Copy, PartialEq, Eq, Debug)]
                         #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-                        #[cfg_attr(feature = "arbitrary-derive", derive(Arbitrary))]
+                        #[cfg_attr(all($($($rsp_fuzz_condition)*,)? feature = "arbitrary-derive"), derive(Arbitrary))]
                         $(#[$rsp_meta])*
                         $(#[@static($srsp_meta)])*
                         pub $rsp_kw [<$Command Response>] {

--- a/src/protocol/wire.rs
+++ b/src/protocol/wire.rs
@@ -79,15 +79,7 @@ pub trait ToWire: Sized {
 /// assert_eq!(T::from_wire_value(T::to_wire_value(x)), Some(x));
 /// # }
 /// ```
-///
-/// Also, the following identity must hold for all types T:
-/// ```
-/// # use manticore::protocol::wire::WireEnum;
-/// # fn test<T: WireEnum + Copy + PartialEq + std::fmt::Debug>(x: T) {
-/// assert_eq!(T::from_name(T::name(x)), Some(x));
-/// # }
-/// ```
-pub trait WireEnum: Sized + Copy + Eq + Ord + Hash {
+pub trait WireEnum: Sized + Copy + Eq {
     /// The unrelying "wire type". This is almost always some kind of
     /// unsigned integer.
     type Wire;
@@ -98,12 +90,6 @@ pub trait WireEnum: Sized + Copy + Eq + Ord + Hash {
     /// Attempts to parse a value of `Self` from the underlying wire
     /// representation.
     fn from_wire_value(wire: Self::Wire) -> Option<Self>;
-
-    /// Converts `self` into a string representation.
-    fn name(self) -> &'static str;
-
-    /// Attempts to convert a value of `Self` from a string representation.
-    fn from_name(str: &str) -> Option<Self>;
 }
 
 impl<'wire, E> FromWire<'wire> for E
@@ -128,6 +114,22 @@ where
     fn to_wire<W: Write>(&self, mut w: W) -> Result<(), Error> {
         self.to_wire_value().write_to(&mut w)?;
         Ok(())
+    }
+}
+
+impl<E> WireEnum for enumflags2::BitFlags<E>
+where
+    E: enumflags2::BitFlag + Eq,
+    E::Numeric: LeInt + Eq,
+{
+    type Wire = E::Numeric;
+
+    fn to_wire_value(self) -> Self::Wire {
+        self.bits()
+    }
+
+    fn from_wire_value(wire: Self::Wire) -> Option<Self> {
+        Self::from_bits(wire).ok()
     }
 }
 
@@ -158,6 +160,9 @@ impl fmt::Display for WireEnumFromStrError {
 /// ```
 /// This macro will generate an implementation of `WireEnum<Wire=u8>` for
 /// the above enum.
+///
+/// This macro will also generate `Display` and `FromStr` implementations,
+/// although those are not required by `WireEnum`'s interface.
 macro_rules! wire_enum {
     ($(#[$meta:meta])* $vis:vis enum $name:ident : $wire:ident {
         $($(#[$meta_variant:meta])* $variant:ident = $value:tt,)*
@@ -189,30 +194,13 @@ macro_rules! wire_enum {
                     _ => None,
                 }
             }
-
-            fn name(self) -> &'static str {
-                match self {
-                    $(
-                        Self::$variant => stringify!($variant),
-                    )*
-                }
-            }
-
-            fn from_name(name: &str) -> Option<Self> {
-                match name {
-                    $(
-                        stringify!($variant) => Some(Self::$variant),
-                    )*
-                    _ => None,
-                }
-            }
         }
 
         impl core::fmt::Display for $name {
             fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-                use $crate::protocol::wire::WireEnum;
-
-                write!(f, "{}", self.name())
+                match self {$(
+                    Self::$variant => stringify!($variant).fmt(f),
+                )*}
             }
         }
 
@@ -220,11 +208,9 @@ macro_rules! wire_enum {
             type Err = $crate::protocol::wire::WireEnumFromStrError;
 
             fn from_str(s: &str) -> Result<Self, $crate::protocol::wire::WireEnumFromStrError> {
-                use $crate::protocol::wire::WireEnum;
-
-                match $name::from_name(s) {
-                    Some(val) => Ok(val),
-                    None => Err($crate::protocol::wire::WireEnumFromStrError),
+                match s {
+                    $(stringify!($variant) => Ok(Self::$variant),)*
+                    _ => Err($crate::protocol::wire::WireEnumFromStrError),
                 }
             }
         }
@@ -233,6 +219,8 @@ macro_rules! wire_enum {
 
 #[cfg(test)]
 mod test {
+    use core::str::FromStr as _;
+
     wire_enum! {
         /// An enum for testing.
         pub enum DemoEnum: u8 {
@@ -249,22 +237,15 @@ mod test {
 
     #[test]
     fn from_name() {
-        use crate::protocol::wire::*;
+        assert_eq!(DemoEnum::from_str("First"), Ok(DemoEnum::First));
+        assert_eq!(DemoEnum::from_str("Second"), Ok(DemoEnum::Second));
 
-        let value = DemoEnum::from_name("Second").expect("from_name failed");
-        assert_eq!(value, DemoEnum::Second);
-
-        let value = DemoEnum::from_name("First").expect("from_name failed");
-        assert_eq!(value, DemoEnum::First);
-
-        assert_eq!(None, DemoEnum::from_name("does not exist"));
+        assert!(DemoEnum::from_str("does not exist").is_err());
     }
 
     #[test]
     fn name() {
-        use crate::protocol::wire::*;
-
-        assert_eq!(DemoEnum::First.name(), "First");
-        assert_eq!(DemoEnum::Second.name(), "Second");
+        assert_eq!(DemoEnum::First.to_string(), "First");
+        assert_eq!(DemoEnum::Second.to_string(), "Second");
     }
 }

--- a/src/server/pa_rot.rs
+++ b/src/server/pa_rot.rs
@@ -205,16 +205,17 @@ impl<'a> PaRot<'a> {
         Resp<protocol::DeviceCapabilities>,
         protocol::Error<protocol::DeviceCapabilities>,
     > {
+        use enumflags2::BitFlags;
         use protocol::capabilities::*;
         let mut crypto = req.capabilities.crypto;
 
         self.opts.ciphers.negotiate(&mut crypto);
         crypto.has_aes = false;
-        crypto.aes_strength = AesKeyStrength::empty();
+        crypto.aes_strength = BitFlags::<AesKeyStrength>::empty();
 
         let capabilities = Capabilities {
             networking: self.opts.networking,
-            security: Security::empty(),
+            security: BitFlags::<Security>::empty(),
 
             has_pfm_support: false,
             has_policy_support: false,


### PR DESCRIPTION
I'm a bit concerned with how fuzzing is grafted into this; it may be prudent to upgrade our libfuzzer, or try to get a patch into arbitrary-derive that adds a way of intercepting an Arbitrary definition into one of the fields...