### PR TITLE
[tables] Add a parser for the Cerberus Message Table format

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ repository = "https://github.com/lowRISC/manticore"
 description = "A WIP implementation of the Cerberus attestation protocol"
 
 [workspace]
-members = [".", "e2e", "tool", "testutil"]
+members = [".", "cerberus-tables", "e2e", "tool", "testutil"]
 
 [dependencies]
 arrayvec = { version = "0.7", default_features = false }

--- a/cerberus-tables/Cargo.toml
+++ b/cerberus-tables/Cargo.toml
@@ -1,0 +1,18 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+[package]
+name = "cerberus-tables"
+version = "0.0.1"
+edition = "2018"
+
+authors = ["lowRISC Contributors"]
+license = "Apache-2.0"
+homepage = "https://opentitan.org/"
+repository = "https://github.com/lowRISC/manticore"
+description = "A parser for the Cerberus Message Table format."
+
+[dependencies]
+annotate-snippets = "0.9.1"
+structopt = "0.3.16"

--- a/cerberus-tables/README.md
+++ b/cerberus-tables/README.md
@@ -1,0 +1,7 @@
+# Cerberus Table Parser
+
+This directory provides a parser for consuming tables from the Cerberus
+specifications that define various binary formats.
+
+Currently, this is only able to parse tables and pretty-print them, although
+we plan to use this to generate Cerberus parsing code for Manticore.

--- a/cerberus-tables/src/ast/fmt.rs
+++ b/cerberus-tables/src/ast/fmt.rs
@@ -196,17 +196,17 @@ impl fmt::Display for Table<'_> {
         // The +2s below is to compensate for the two spaces around the
         // pipes not being included in the widths.
         write!(f, "|")?;
-        for _ in 0..width1+2 {
+        for _ in 0..width1 + 2 {
             write!(f, "-")?;
         }
         write!(f, "|")?;
-        for _ in 0..width2+2 {
+        for _ in 0..width2 + 2 {
             write!(f, "-")?;
         }
         write!(f, "|")?;
 
         if has_descs {
-            for _ in 0..width3+2 {
+            for _ in 0..width3 + 2 {
                 write!(f, "-")?;
             }
             write!(f, "|")?;

--- a/cerberus-tables/src/ast/fmt.rs
+++ b/cerberus-tables/src/ast/fmt.rs
@@ -1,0 +1,234 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::fmt;
+
+use crate::ast::*;
+
+impl fmt::Display for Ident<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.name())
+    }
+}
+
+impl fmt::Display for Path<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        for (i, component) in self.components.iter().enumerate() {
+            if i == 0 {
+                write!(f, "{}", component)?;
+            } else {
+                write!(f, ".{}", component)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+impl fmt::Display for Lit<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self.base {
+            Base::Dec => write!(f, "{}", self.value),
+            Base::Hex => write!(
+                f,
+                "0x{:01$x}",
+                self.value,
+                self.bit_width.unwrap_or(0) / 4
+            ),
+            Base::Bin => {
+                write!(f, "0b{:01$b}", self.value, self.bit_width.unwrap_or(0))
+            }
+        }
+    }
+}
+
+impl fmt::Display for Type<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match &self.kind {
+            TypeKind::Bits(width) => write!(f, "b{}", width),
+            TypeKind::Lit(l) => write!(f, "{}", l),
+            TypeKind::Path(p) => write!(f, "{}", p),
+            TypeKind::Mapping { mapping, field } => {
+                write!(f, "{}({})", mapping, field)
+            }
+            TypeKind::FixedArray {
+                ty: Some(ty),
+                extent,
+            } => write!(f, "{}[{}]", ty, extent),
+            TypeKind::FixedArray { ty: None, extent } => {
+                write!(f, "[{}]", extent)
+            }
+            TypeKind::VariableArray {
+                ty: Some(ty),
+                extent_field,
+            } => write!(f, "{}[{}]", ty, extent_field),
+            TypeKind::VariableArray {
+                ty: None,
+                extent_field,
+            } => write!(f, "[{}]", extent_field),
+            TypeKind::PrefixedArray {
+                ty: Some(ty),
+                extent_bits,
+            } => write!(f, "{}[b{}]", ty, extent_bits),
+            TypeKind::PrefixedArray {
+                ty: None,
+                extent_bits,
+            } => write!(f, "[b{}]", extent_bits),
+            TypeKind::IndefiniteArray { ty: Some(ty) } => {
+                write!(f, "{}...", ty)
+            }
+            TypeKind::IndefiniteArray { ty: None } => write!(f, "..."),
+            TypeKind::Aligned {
+                ty: Some(ty),
+                alignment,
+            } => write!(f, "{} align({})", ty, alignment),
+            TypeKind::Aligned {
+                ty: None,
+                alignment,
+            } => write!(f, "align({})", alignment),
+        }
+    }
+}
+
+impl fmt::Display for Table<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        // First, write out the opening heading.
+        match &self.kind {
+            TableKind::Message { .. } => {
+                writeln!(f, "`message {}`", self.name)?
+            }
+            TableKind::Enum { .. } => writeln!(f, "`enum {}`", self.name)?,
+            TableKind::ValueMap { from, .. } => {
+                writeln!(f, "`enum {}({})`", self.name, from)?
+            }
+            TableKind::TypeMap { from, .. } => {
+                writeln!(f, "`enum {}({})`", self.name, from)?
+            }
+        }
+
+        // To make sure everything is nicely aligned, we need to pre-format all
+        // rows more-or-less.
+        let rows: Vec<_> = match &self.kind {
+            TableKind::Message { rows, .. } => rows
+                .iter()
+                .map(|row| {
+                    (
+                        format!("`{}`", row.value),
+                        format!("`{}`", row.name),
+                        row.desc.map(|d| d.text().trim()),
+                    )
+                })
+                .collect(),
+            TableKind::Enum { rows, .. } => rows
+                .iter()
+                .map(|row| {
+                    (
+                        format!("`{}`", row.value),
+                        format!("`{}`", row.name),
+                        row.desc.map(|d| d.text().trim()),
+                    )
+                })
+                .collect(),
+            TableKind::ValueMap { rows, .. } => rows
+                .iter()
+                .map(|row| {
+                    (
+                        format!("`{}`", row.value),
+                        format!("`{}`", row.name),
+                        row.desc.map(|d| d.text().trim()),
+                    )
+                })
+                .collect(),
+            TableKind::TypeMap { rows, .. } => rows
+                .iter()
+                .map(|row| {
+                    (
+                        format!("`{}`", row.value),
+                        format!("`{}`", row.name),
+                        row.desc.map(|d| d.text().trim()),
+                    )
+                })
+                .collect(),
+        };
+
+        let first_col_heading = match &self.kind {
+            TableKind::Message { .. } | TableKind::TypeMap { .. } => "Type",
+            _ => "Value",
+        };
+        let has_descs =
+            rows.first().map(|(_, _, d)| d.is_some()).unwrap_or(true);
+
+        let width1 = rows
+            .iter()
+            .map(|(x, _, _)| x.len())
+            .max()
+            .unwrap_or(0)
+            .max(first_col_heading.len());
+        let width2 = rows
+            .iter()
+            .map(|(_, x, _)| x.len())
+            .max()
+            .unwrap_or(0)
+            .max("Name".len());
+        let width3 = rows
+            .iter()
+            .map(|(_, _, x)| x.map(|d| d.len()).unwrap_or(0))
+            .max()
+            .unwrap_or(0)
+            .max("Description".len());
+
+        // Next, we write the column headings.
+        write!(
+            f,
+            "| {:width1$} | {:width2$} |",
+            first_col_heading,
+            "Name",
+            width1 = width1,
+            width2 = width2
+        )?;
+        if has_descs {
+            write!(f, " {:width3$} |", "Description", width3 = width3)?;
+        }
+        writeln!(f)?;
+
+        // Next, the heading separator rule.
+        //
+        // The +2s below is to compensate for the two spaces around the
+        // pipes not being included in the widths.
+        write!(f, "|")?;
+        for _ in 0..width1+2 {
+            write!(f, "-")?;
+        }
+        write!(f, "|")?;
+        for _ in 0..width2+2 {
+            write!(f, "-")?;
+        }
+        write!(f, "|")?;
+
+        if has_descs {
+            for _ in 0..width3+2 {
+                write!(f, "-")?;
+            }
+            write!(f, "|")?;
+        }
+        writeln!(f)?;
+
+        // Finally, write out the rows.
+        for (first, name, desc) in rows {
+            write!(
+                f,
+                "| {:width1$} | {:width2$} |",
+                first,
+                name,
+                width1 = width1,
+                width2 = width2
+            )?;
+            if let Some(desc) = desc {
+                write!(f, " {:width3$} |", desc, width3 = width3)?;
+            }
+            writeln!(f)?;
+        }
+
+        Ok(())
+    }
+}

--- a/cerberus-tables/src/ast/fmt.rs
+++ b/cerberus-tables/src/ast/fmt.rs
@@ -280,6 +280,8 @@ impl fmt::Display for TableWithOptions<'_> {
                     } else {
                         line.push_str(" |");
                     }
+                } else {
+                    line.push_str(" |");
                 }
             }
             writeln!(f, "{}", line)?;

--- a/cerberus-tables/src/ast/mod.rs
+++ b/cerberus-tables/src/ast/mod.rs
@@ -11,6 +11,8 @@ use std::path::PathBuf;
 mod fmt;
 mod parser;
 
+pub use fmt::TableWithOptions;
+
 /// A Markdown file taken as parsing input.
 #[derive(Clone)]
 pub struct MarkdownFile {

--- a/cerberus-tables/src/ast/mod.rs
+++ b/cerberus-tables/src/ast/mod.rs
@@ -1,0 +1,343 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Parsing and AST for Cerberus Tables.
+//!
+//! See [`MarkdownFile::parse_tables()`].
+
+use std::fmt;
+use std::path::PathBuf;
+
+mod parser;
+
+/// A Markdown file taken as parsing input.
+#[derive(Clone)]
+pub struct MarkdownFile {
+    /// The name of the file, for error-reporting purposes.
+    pub file_name: PathBuf,
+    /// The entire text of the file.
+    pub text: String,
+}
+
+impl MarkdownFile {
+    /// Parses a specification from the given [`MarkdownFile`], returning
+    /// an array of tables.
+    pub fn parse_tables(&self) -> (Vec<Table>, Vec<Error>) {
+        let mut ctx = parser::Context::new(self);
+        let mut tables = Vec::new();
+        let mut errors = Vec::new();
+        while ctx.peek().is_some() {
+            match Table::parse(&mut ctx) {
+                Ok(Some(t)) => tables.push(t),
+                Ok(None) => { /* This wasn't a table! */ }
+                Err(e) => errors.push(e),
+            }
+
+            // Skip forward until the end of the current line.
+            let mut seen_newline = false;
+            ctx.skip(|_, c| {
+                if c == '\n' {
+                    seen_newline = true;
+                }
+                seen_newline == (c == '\n')
+            });
+        }
+        (tables, errors)
+    }
+}
+
+impl fmt::Debug for MarkdownFile {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "MarkdownFile({})", self.file_name.display())
+    }
+}
+
+/// A span of code inside of a [`MarkdownFile`].
+#[derive(Copy, Clone)]
+pub struct Span<'md> {
+    src: &'md MarkdownFile,
+    range: (parser::Cursor, parser::Cursor),
+}
+
+impl<'md> Span<'md> {
+    /// Returns the wrapped [`MarkdownFile`].
+    pub fn src(self) -> &'md MarkdownFile {
+        self.src
+    }
+
+    /// Returns the textual content of this span.
+    pub fn text(self) -> &'md str {
+        &self.src().text[self.range.0.byte..self.range.1.byte]
+    }
+
+    /// Returns an iterator over the lines spanned by this span.
+    pub fn lines(self) -> impl Iterator<Item = (usize, &'md str)> {
+        let start_line = self.range.0.line - 1;
+        let end_line = self.range.0.line;
+        self.src()
+            .text
+            .lines()
+            .enumerate()
+            .skip(start_line)
+            .take(end_line - start_line)
+    }
+
+    /// Creates an error wrapping this span.
+    fn error(self, error: ErrorKind) -> Error<'md> {
+        Error {
+            kind: error,
+            span: self,
+        }
+    }
+}
+
+impl fmt::Debug for Span<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "Span({}:{}:{}, {}..{})",
+            self.src.file_name.display(),
+            self.range.0.line,
+            self.range.0.col,
+            self.range.0.byte,
+            self.range.1.byte
+        )
+    }
+}
+
+/// A single identifier, i.e. `[a-zA-Z_][0-9a-zA-Z]*`.
+#[derive(Copy, Clone)]
+pub struct Ident<'md>(Span<'md>);
+
+impl<'md> Ident<'md> {
+    /// Returns the wrapped [`MarkdownFile`].
+    pub fn span(self) -> Span<'md> {
+        self.0
+    }
+
+    /// Returns the textual content of this span.
+    pub fn name(self) -> &'md str {
+        self.0.text()
+    }
+
+    fn as_bits_type(self) -> Option<u64> {
+        if !self.name().starts_with("b")
+            || !self.name().chars().all(|c| c.is_ascii_digit())
+        {
+            return None;
+        }
+        Some(self.name().parse::<u64>().unwrap())
+    }
+}
+
+impl fmt::Debug for Ident<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "{:?} @ {}..{}",
+            self.name(),
+            self.span().range.0.byte,
+            self.span().range.1.byte
+        )
+    }
+}
+
+/// A path, i.e., a sequence of dot-separated identifiers.
+#[derive(Clone, Debug)]
+pub struct Path<'md> {
+    /// The path's components.
+    pub components: Vec<Ident<'md>>,
+    /// This path but in canonicalized form.
+    ///
+    /// Not present until after canonicalization.
+    pub canonicalized: Option<Vec<&'md str>>,
+    /// The node's span.
+    pub span: Span<'md>,
+}
+
+/// An integer literal, in decimal, hex, or binary.
+#[derive(Copy, Clone, Debug)]
+pub struct Lit<'md> {
+    /// The width of this literal, in bits.
+    ///
+    /// This includes any leading zeroes for binary or hex literals.
+    ///
+    /// Not present for decimal literals.
+    pub bit_width: Option<usize>,
+    /// The value of this literal.
+    pub value: u64,
+    /// The base the integer was in.
+    pub base: Base,
+    /// The node's span.
+    pub span: Span<'md>,
+}
+
+/// An integer base: decimal, binary, or hexadecimal.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[allow(missing_docs)]
+pub enum Base {
+    Bin,
+    Dec,
+    Hex,
+}
+
+/// A type, such as raw bits or an array.
+#[derive(Clone, Debug)]
+pub struct Type<'md> {
+    /// The kind of type this is.
+    pub kind: TypeKind<'md>,
+    /// The node's span.
+    pub span: Span<'md>,
+}
+
+/// A [`Type`] kind.
+#[derive(Clone, Debug)]
+pub enum TypeKind<'md> {
+    /// A raw bit string of fixed length.
+    ///
+    /// E.g. `b1`, `b8`, or `b256`.
+    Bits(u64),
+
+    /// A literal value.
+    ///
+    /// E.g. `0xabcd`.
+    Lit(Lit<'md>),
+
+    /// A reference to some other table by path.
+    ///
+    /// E.g. `Foo.Bar.Baz`.
+    Path(Path<'md>),
+
+    /// An enum mapping.
+    ///
+    /// E.g. `HashLength(hash_type)`.
+    Mapping {
+        /// A reference to the enum mapping table.
+        mapping: Path<'md>,
+        /// The mapped field.
+        field: Ident<'md>,
+    },
+
+    /// An array of fixed extent.
+    ///
+    /// E.g. `Foo[6]`.
+    FixedArray {
+        /// The component type of this array.
+        ty: Option<Box<Type<'md>>>,
+        /// The fixed extent.
+        extent: Lit<'md>,
+    },
+
+    /// An array of variable extent.
+    ///
+    /// E.g. `Foo[some_length]`.
+    VariableArray {
+        /// The component type of this array.
+        ty: Option<Box<Type<'md>>>,
+        /// The name of the field defining the extent.
+        extent_field: Ident<'md>,
+    },
+
+    /// An array with a length prefix.
+    PrefixedArray {
+        /// The component type of this array.
+        ty: Option<Box<Type<'md>>>,
+        /// The bit-width of the length prefix.
+        extent_bits: u64,
+    },
+
+    /// An array of indefinite length.
+    IndefiniteArray {
+        /// The component type of this array.
+        ty: Option<Box<Type<'md>>>,
+    },
+
+    /// An aligned type.
+    Aligned {
+        /// The type being aligned.
+        ty: Option<Box<Type<'md>>>,
+        /// The number of bytes to align to.
+        alignment: Lit<'md>,
+    },
+}
+
+/// A row of a [`Table`] with values of type `Type`.
+#[derive(Clone, Debug)]
+pub struct TableRow<'md, Type> {
+    /// The value in the first column.
+    pub value: Type,
+    /// The name in the second column.
+    pub name: Ident<'md>,
+    /// The optional description in the third column.
+    pub desc: Option<Span<'md>>,
+    /// This node's span.
+    pub span: Span<'md>,
+}
+
+/// A table defining a message or enum.
+///
+/// This is a Markdown table prefixed with a line starting with wither
+/// `` `message `` or `` `enum ``.
+#[derive(Clone, Debug)]
+pub struct Table<'md> {
+    /// The name of the table itself.
+    pub name: Path<'md>,
+    /// This table's kind.
+    pub kind: TableKind<'md>,
+    /// This node's span.
+    pub span: Span<'md>,
+}
+
+/// A [`Table`] kind.
+#[derive(Clone, Debug)]
+pub enum TableKind<'md> {
+    /// A basic message table.
+    Message {
+        /// The table's rows.
+        rows: Vec<TableRow<'md, Type<'md>>>,
+    },
+    /// A basic enum table.
+    Enum {
+        /// The table's rows.
+        rows: Vec<TableRow<'md, Lit<'md>>>,
+    },
+    /// an enum mapping from enum values to literal values.
+    ValueMap {
+        /// the enum being mapped.
+        from: Path<'md>,
+        /// The table's rows.
+        rows: Vec<TableRow<'md, Lit<'md>>>,
+    },
+    /// an enum mapping from enum values to types.
+    TypeMap {
+        /// The table's rows.
+        from: Path<'md>,
+        /// The table's rows.
+        rows: Vec<TableRow<'md, Type<'md>>>,
+    },
+}
+
+/// A parse error.
+#[derive(Clone, Debug)]
+pub struct Error<'md> {
+    /// The location where the error occured.
+    pub span: Span<'md>,
+    /// The kind of error this is.
+    pub kind: ErrorKind,
+}
+
+/// An [`Error`] kind.
+#[derive(Clone, Debug)]
+pub enum ErrorKind {
+    /// Indicates that an integer failed to parse.
+    BadInt,
+    /// Indicates that a delimited like `[` was not matched.
+    Unmatched,
+    /// Indicates that something expected was missing, described by the
+    /// string argument.
+    Expected(String),
+    /// Indicates that something unexpected was found, described by the
+    /// string argument.
+    Unexpected(String),
+}

--- a/cerberus-tables/src/ast/mod.rs
+++ b/cerberus-tables/src/ast/mod.rs
@@ -71,6 +71,11 @@ impl<'md> Span<'md> {
         &self.src().text[self.range.0.byte..self.range.1.byte]
     }
 
+    /// Returns the byte range of this span.
+    pub fn byte_range(self) -> (usize, usize) {
+        (self.range.0.byte, self.range.1.byte)
+    }
+
     /// Returns an iterator over the lines spanned by this span.
     pub fn lines(self) -> impl Iterator<Item = (usize, &'md str)> {
         let start_line = self.range.0.line - 1;

--- a/cerberus-tables/src/ast/mod.rs
+++ b/cerberus-tables/src/ast/mod.rs
@@ -6,9 +6,9 @@
 //!
 //! See [`MarkdownFile::parse_tables()`].
 
-use std::fmt;
 use std::path::PathBuf;
 
+mod fmt;
 mod parser;
 
 /// A Markdown file taken as parsing input.
@@ -47,8 +47,8 @@ impl MarkdownFile {
     }
 }
 
-impl fmt::Debug for MarkdownFile {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+impl std::fmt::Debug for MarkdownFile {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "MarkdownFile({})", self.file_name.display())
     }
 }
@@ -92,8 +92,8 @@ impl<'md> Span<'md> {
     }
 }
 
-impl fmt::Debug for Span<'_> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+impl std::fmt::Debug for Span<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(
             f,
             "Span({}:{}:{}, {}..{})",
@@ -131,8 +131,8 @@ impl<'md> Ident<'md> {
     }
 }
 
-impl fmt::Debug for Ident<'_> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+impl std::fmt::Debug for Ident<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(
             f,
             "{:?} @ {}..{}",

--- a/cerberus-tables/src/ast/mod.rs
+++ b/cerberus-tables/src/ast/mod.rs
@@ -129,7 +129,7 @@ impl<'md> Ident<'md> {
     }
 
     fn as_bits_type(self) -> Option<u64> {
-        if !self.name().starts_with("b")
+        if !self.name().starts_with('b')
             || !self.name().chars().all(|c| c.is_ascii_digit())
         {
             return None;

--- a/cerberus-tables/src/ast/parser.rs
+++ b/cerberus-tables/src/ast/parser.rs
@@ -249,7 +249,6 @@ impl<'md> Lit<'md> {
                 Base::Dec => span.text(),
                 _ => &span.text()[2..],
             };
-            dbg!(digits);
             let (bit_width, radix) = match base {
                 Base::Dec => (None, 10),
                 Base::Bin => (Some(digits.len()), 2),

--- a/cerberus-tables/src/ast/parser.rs
+++ b/cerberus-tables/src/ast/parser.rs
@@ -1,0 +1,640 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::ast::*;
+
+/// Parse state for the table parser.
+pub struct Context<'md> {
+    src: &'md MarkdownFile,
+    cursor: Cursor,
+    cursor_stack: Vec<Cursor>,
+}
+
+/// A position in source code.
+///
+/// `line` and `col` are one-indexed.
+#[derive(Copy, Clone, Debug)]
+pub struct Cursor {
+    /// The byte offset of this position.
+    pub byte: usize,
+    /// The line of this position.
+    pub line: usize,
+    /// The column of this position.
+    pub col: usize,
+}
+
+impl Cursor {
+    /// Advances the cursor, triggering a line wrap when
+    /// hitting a newline.
+    pub fn advance(&mut self, c: char) {
+        self.byte += c.len_utf8();
+        if c == '\n' {
+            self.line += 1;
+            self.col = 1;
+        } else {
+            self.col += 1;
+        }
+    }
+}
+
+impl<'md> Context<'md> {
+    /// Creates a new parser state.
+    pub fn new(src: &'md MarkdownFile) -> Self {
+        Self {
+            src,
+            cursor: Cursor {
+                byte: 0,
+                line: 1,
+                col: 1,
+            },
+            cursor_stack: Vec::new(),
+        }
+    }
+
+    /// Executes `f` inside of a scope, such that `span()` always referrs
+    /// to the start of the scope.
+    ///
+    /// If `f` returns an error, the cursor is backtracked to where it was
+    /// before `f` was run.
+    pub fn try_scope<T, E>(
+        &mut self,
+        f: impl FnOnce(&mut Self) -> Result<T, E>,
+    ) -> Result<T, E> {
+        self.skip_spaces();
+        self.cursor_stack.push(self.cursor);
+        let x = f(self);
+        let prev = self
+            .cursor_stack
+            .pop()
+            .expect("popped empty cursor stack; this is a bug");
+        if x.is_err() {
+            self.cursor = prev;
+        }
+        x
+    }
+
+    /// Like `try_scope()` but infallible.
+    pub fn scope<T>(&mut self, f: impl FnOnce(&mut Self) -> T) -> T {
+        let x: Result<_, std::convert::Infallible> =
+            self.try_scope(|x| Ok(f(x)));
+        x.unwrap()
+    }
+
+    /// Gets a span from the start of the innermost scope up until
+    /// the current cursor.
+    pub fn span(&self) -> Span<'md> {
+        let start = *self
+            .cursor_stack
+            .last()
+            .expect("popped empty cursor stack; this is a bug");
+        Span {
+            src: self.src,
+            range: (start, self.cursor),
+        }
+    }
+
+    /// Gets a zero-width span corresponding to the cursor.
+    pub fn cursor(&self) -> Span<'md> {
+        Span {
+            src: self.src,
+            range: (self.cursor, self.cursor),
+        }
+    }
+
+    /// Peeks the next character.
+    pub fn peek(&self) -> Option<char> {
+        // Getting the character at a byte offset is oddly annoying.
+        self.src.text.get(self.cursor.byte..)?.chars().next()
+    }
+
+    /// Peeks the next prefix that is `byte_len` bytes long.
+    pub fn peek_prefix(&self, byte_len: usize) -> Option<&'md str> {
+        self.src
+            .text
+            .get(self.cursor.byte..self.cursor.byte + byte_len)
+    }
+
+    /// Consumes a prefix with the exact value `prefix`, returning a span for
+    /// the consumed text.
+    pub fn take_str(&mut self, prefix: &str) -> Option<Span<'md>> {
+        self.skip_spaces();
+        if !self.src.text.get(self.cursor.byte..)?.starts_with(prefix) {
+            return None;
+        }
+        self.scope(|zelf| {
+            prefix.chars().for_each(|c| zelf.cursor.advance(c));
+            Some(zelf.span())
+        })
+    }
+
+    /// Consumes text so long as `cond` is true, returning the span of
+    /// consumed text.
+    ///
+    /// `cond`'s first argument is the character index from the start of
+    /// the `take_while` operation.
+    pub fn take_while(
+        &mut self,
+        mut cond: impl FnMut(usize, char) -> bool,
+    ) -> Span<'md> {
+        self.scope(|zelf| {
+            let mut idx = 0;
+            while let Some(c) = zelf.peek() {
+                if !cond(idx, c) {
+                    break;
+                }
+                zelf.cursor.advance(c);
+                idx += 1;
+            }
+            zelf.span()
+        })
+    }
+
+    /// Like `take_while`, but skips the characters instead and returns how
+    /// many characters were skipped.
+    pub fn skip(&mut self, mut cond: impl FnMut(usize, char) -> bool) -> usize {
+        let mut i = 0;
+        while let Some(c) = self.peek() {
+            if !cond(i, c) {
+                break;
+            }
+            self.cursor.advance(c);
+            i += 1;
+        }
+        i
+    }
+
+    /// Like `skip` but skips only spaces.
+    pub fn skip_spaces(&mut self) -> usize {
+        self.skip(|_, c| c == ' ')
+    }
+
+    /// Runs the given parsing function; if it returns `Ok(None)`, returns
+    /// a `ErrorKind::Expected` with the given `expected`.
+    pub fn expect<T>(
+        &mut self,
+        parse: impl FnOnce(&mut Self) -> Result<Option<T>, Error<'md>>,
+        expected: impl fmt::Display,
+    ) -> Result<T, Error<'md>> {
+        parse(self)?.ok_or_else(|| Error {
+            kind: ErrorKind::Expected(expected.to_string()),
+            span: self.cursor(),
+        })
+    }
+
+    /// Like `expect`, but expects a specific string.
+    pub fn expect_str(
+        &mut self,
+        prefix: &str,
+        expected: impl fmt::Display,
+    ) -> Result<Span<'md>, Error<'md>> {
+        self.expect(|ctx| Ok(ctx.take_str(prefix)), expected)
+    }
+}
+
+impl<'md> Ident<'md> {
+    pub fn parse(ctx: &mut Context<'md>) -> Result<Option<Self>, Error<'md>> {
+        let id = Self(ctx.take_while(|i, c| {
+            (i > 0 && c.is_ascii_digit()) || c.is_ascii_alphabetic() || c == '_'
+        }));
+
+        if id.name().is_empty() {
+            Ok(None)
+        } else {
+            Ok(Some(id))
+        }
+    }
+}
+
+impl<'md> Path<'md> {
+    pub fn parse(ctx: &mut Context<'md>) -> Result<Option<Self>, Error<'md>> {
+        ctx.try_scope(|ctx| {
+            let mut components = Vec::new();
+            while let Some(id) = Ident::parse(ctx)? {
+                components.push(id);
+                if ctx.take_str(".").is_none() {
+                    break;
+                }
+            }
+
+            if components.is_empty() {
+                return Ok(None);
+            }
+            Ok(Some(Self {
+                components,
+                canonicalized: None,
+                span: ctx.span(),
+            }))
+        })
+    }
+}
+
+impl<'md> Lit<'md> {
+    pub fn parse(ctx: &mut Context<'md>) -> Result<Option<Self>, Error<'md>> {
+        ctx.try_scope(|ctx| {
+            let base = match ctx.peek_prefix(2) {
+                Some("0x") | Some("0X") => Base::Hex,
+                Some("0b") | Some("0B") => Base::Bin,
+                _ => Base::Dec,
+            };
+
+            let span = ctx.take_while(|_, c| c.is_ascii_alphanumeric());
+            if span.text().is_empty() {
+                return Ok(None);
+            }
+
+            let digits = match base {
+                Base::Dec => span.text(),
+                _ => &span.text()[2..],
+            };
+            dbg!(digits);
+            let (bit_width, radix) = match base {
+                Base::Dec => (None, 10),
+                Base::Bin => (Some(digits.len()), 2),
+                Base::Hex => (Some(digits.len() * 4), 16),
+            };
+
+            let value = u64::from_str_radix(digits, radix)
+                .map_err(|_| span.error(ErrorKind::BadInt))?;
+
+            Ok(Some(Self {
+                bit_width,
+                value,
+                base,
+                span,
+            }))
+        })
+    }
+}
+
+impl<'md> Type<'md> {
+    pub fn parse(ctx: &mut Context<'md>) -> Result<Option<Self>, Error<'md>> {
+        ctx.try_scope(|ctx| {
+            let mut ty = Path::parse(ctx)?
+                .map(|path| {
+                    if let Some(width) = path.components[0].as_bits_type() {
+                        if path.components.len() > 1 {
+                            return Err(path.span.error(
+                                ErrorKind::Unexpected(
+                                    "extra path components".into(),
+                                ),
+                            ));
+                        }
+
+                        Ok(Type {
+                            kind: TypeKind::Bits(width),
+                            span: ctx.span(),
+                        })
+                    } else if let Some(paren) = ctx.take_str("(") {
+                        let field = ctx.expect(Ident::parse, "identifier")?;
+                        ctx.take_str(")")
+                            .ok_or(paren.error(ErrorKind::Unmatched))?;
+                        Ok(Type {
+                            kind: TypeKind::Mapping {
+                                mapping: path,
+                                field,
+                            },
+                            span: ctx.span(),
+                        })
+                    } else {
+                        Ok(Type {
+                            span: path.span,
+                            kind: TypeKind::Path(path),
+                        })
+                    }
+                })
+                .transpose()?;
+            if ty.is_none() {
+                if let Ok(Some(lit)) = Lit::parse(ctx) {
+                    return Ok(Some(Type {
+                        kind: TypeKind::Lit(lit),
+                        span: ctx.span(),
+                    }));
+                }
+            }
+
+            loop {
+                let brack = match ctx.take_str("[") {
+                    Some(brack) => brack,
+                    None => break,
+                };
+                if let Ok(Some(ident)) = Ident::parse(ctx) {
+                    if let Some(extent_bits) = ident.as_bits_type() {
+                        ty = Some(Type {
+                            kind: TypeKind::PrefixedArray {
+                                ty: ty.map(Box::new),
+                                extent_bits,
+                            },
+                            span: ctx.span(),
+                        });
+                    } else {
+                        ty = Some(Self {
+                            kind: TypeKind::VariableArray {
+                                ty: ty.map(Box::new),
+                                extent_field: ident,
+                            },
+                            span: ctx.span(),
+                        });
+                    }
+                } else if let Ok(Some(extent)) = Lit::parse(ctx) {
+                    ty = Some(Self {
+                        kind: TypeKind::FixedArray {
+                            ty: ty.map(Box::new),
+                            extent,
+                        },
+                        span: ctx.span(),
+                    });
+                } else {
+                    return Err(ctx.cursor().error(ErrorKind::Expected(
+                        "literal, identifier, or bits type".into(),
+                    )));
+                }
+
+                ctx.take_str("]").ok_or(Error {
+                    kind: ErrorKind::Unmatched,
+                    span: brack,
+                })?;
+            }
+
+            if ctx.take_str("...").is_some() {
+                ty = Some(Type {
+                    kind: TypeKind::IndefiniteArray {
+                        ty: ty.map(Box::new),
+                    },
+                    span: ctx.span(),
+                });
+            }
+
+            if ctx.take_str("align").is_some() {
+                let paren = ctx.expect_str("(", "`(`")?;
+                let lit = ctx.expect(Lit::parse, "literal")?;
+                ctx.take_str(")").ok_or(paren.error(ErrorKind::Unmatched))?;
+
+                ty = Some(Self {
+                    kind: TypeKind::Aligned {
+                        ty: ty.map(Box::new),
+                        alignment: lit,
+                    },
+                    span: ctx.span(),
+                });
+            }
+
+            Ok(ty)
+        })
+    }
+}
+
+/// Helper for finding the start of tables.
+struct TableHeader<'md> {
+    kw: Ident<'md>,
+    path: Path<'md>,
+    arg: Option<Path<'md>>,
+    first_col: Ident<'md>,
+    has_desc: bool,
+}
+
+impl<'md> TableHeader<'md> {
+    pub fn parse(ctx: &mut Context<'md>) -> Result<Option<Self>, Error<'md>> {
+        // The first line is:
+        // `ident path(path)`\n
+        //
+        // If this is matched exactly without errors (but with arbitrary
+        // whitespace) we assume we're looking at a table.
+
+        if ctx.take_str("`").is_none() {
+            return Ok(None);
+        }
+
+        let kw = match Ident::parse(ctx)? {
+            Some(x) => x,
+            None => return Ok(None),
+        };
+
+        let path = match Path::parse(ctx)? {
+            Some(x) => x,
+            None => return Ok(None),
+        };
+
+        let arg = if ctx.take_str("(").is_some() {
+            let path = match Path::parse(ctx)? {
+                Some(x) => x,
+                None => return Ok(None),
+            };
+            if ctx.take_str(")").is_none() {
+                return Ok(None);
+            }
+            Some(path)
+        } else {
+            None
+        };
+
+        if ctx.take_str("`\n").is_none() {
+            return Ok(None);
+        }
+
+        // Definitely a table a this point.
+
+        // Parse the first row:
+        // | $ident | Name | (Description |)?
+        ctx.expect_str("|", "pipe")?;
+        let first_col = ctx.expect(Ident::parse, "identifier")?;
+
+        ctx.expect_str("|", "pipe")?;
+        ctx.expect_str("Name", "`Name`")?;
+        ctx.expect_str("|", "pipe")?;
+
+        let has_desc = ctx.take_str("Description").is_some();
+        if has_desc {
+            ctx.expect_str("|", "pipe")?;
+        }
+
+        ctx.expect_str("\n", "newline")?;
+
+        // Parse the second row:
+        // |----|----:|:----|
+        ctx.expect_str("|", "pipe")?;
+        ctx.skip(|_, c| ":-".contains(c));
+        ctx.expect_str("|", "pipe")?;
+        ctx.skip(|_, c| ":-".contains(c));
+        ctx.expect_str("|", "pipe")?;
+
+        if has_desc {
+            ctx.skip(|_, c| ":-".contains(c));
+            ctx.expect_str("|", "pipe")?;
+        }
+        ctx.expect_str("\n", "newline")?;
+
+        Ok(Some(TableHeader {
+            kw,
+            path,
+            arg,
+            first_col,
+            has_desc,
+        }))
+    }
+}
+
+impl<'md, Type> TableRow<'md, Type> {
+    pub fn parse(
+        ctx: &mut Context<'md>,
+        parse_desc: bool,
+        parse: impl FnOnce(&mut Context<'md>) -> Result<Option<Type>, Error<'md>>,
+        expected: impl fmt::Display,
+    ) -> Result<Option<Self>, Error<'md>> {
+        ctx.scope(|ctx| {
+            ctx.expect_str("|", "pipe")?;
+            ctx.expect_str("`", "backtick")?;
+            let value = ctx.expect(parse, expected)?;
+            ctx.expect_str("`", "backtick")?;
+
+            ctx.expect_str("|", "pipe")?;
+            ctx.expect_str("`", "backtick")?;
+            let name = ctx.expect(Ident::parse, "identifier")?;
+            ctx.expect_str("`", "backtick")?;
+
+            let desc = if parse_desc {
+                ctx.expect_str("|", "pipe")?;
+
+                let mut in_backticks = false;
+                let desc = ctx.take_while(|_, c| {
+                    if c == '`' {
+                        in_backticks = !in_backticks;
+                    }
+
+                    in_backticks || c != '|'
+                });
+
+                Some(desc)
+            } else {
+                None
+            };
+            ctx.expect_str("|", "pipe")?;
+            ctx.expect_str("\n", "newline")?;
+
+            Ok(Some(TableRow {
+                value,
+                name,
+                desc,
+                span: ctx.span(),
+            }))
+        })
+    }
+}
+
+impl<'md> Table<'md> {
+    pub fn parse(ctx: &mut Context<'md>) -> Result<Option<Self>, Error<'md>> {
+        pub fn collect_rows<'md, Type>(
+            ctx: &mut Context<'md>,
+            parse_desc: bool,
+            mut parse: impl FnMut(
+                &mut Context<'md>,
+            ) -> Result<Option<Type>, Error<'md>>,
+            expected: impl fmt::Display,
+        ) -> Result<Vec<TableRow<'md, Type>>, Error<'md>> {
+            let mut rows = Vec::new();
+            while let Some('|') = ctx.peek() {
+                rows.push(ctx.expect(
+                    |ctx| TableRow::parse(ctx, parse_desc, &mut parse, "type"),
+                    &expected,
+                )?);
+            }
+            Ok(rows)
+        }
+
+        ctx.scope(|ctx| {
+            let header = match TableHeader::parse(ctx)? {
+                Some(h) => h,
+                None => return Ok(None),
+            };
+
+            match (
+                header.kw.name(),
+                header.arg,
+                header.first_col.name(),
+                header.has_desc,
+            ) {
+                // `message` tables.
+                ("message", None, "Type", true) => Ok(Some(Table {
+                    name: header.path,
+                    kind: TableKind::Message {
+                        rows: collect_rows(ctx, true, Type::parse, "type")?,
+                    },
+                    span: ctx.span(),
+                })),
+                ("message", None, "Type", false) => {
+                    return Err(header.path.span.error(ErrorKind::Expected(
+                        "descriptions for message fields".into(),
+                    )))
+                }
+                ("message", Some(arg), _, _) => {
+                    return Err(arg.span.error(ErrorKind::Unexpected(
+                        "argument in message".into(),
+                    )))
+                }
+                ("message", None, _, _) => {
+                    return Err(header
+                        .first_col
+                        .span()
+                        .error(ErrorKind::Expected("`Type`".into())))
+                }
+
+                // `enum` tables without an argument.
+                ("enum", None, "Value", true) => Ok(Some(Table {
+                    name: header.path,
+                    kind: TableKind::Enum {
+                        rows: collect_rows(ctx, true, Lit::parse, "literal")?,
+                    },
+                    span: ctx.span(),
+                })),
+                ("enum", None, "Value", false) => {
+                    return Err(header.path.span.error(ErrorKind::Expected(
+                        "descriptions for enum variants".into(),
+                    )))
+                }
+                ("enum", None, _, _) => {
+                    return Err(header
+                        .first_col
+                        .span()
+                        .error(ErrorKind::Expected("`Value`".into())))
+                }
+
+                // `enum` tables with an argument.
+                ("enum", Some(arg), "Type", _) => Ok(Some(Table {
+                    name: header.path,
+                    kind: TableKind::TypeMap {
+                        rows: collect_rows(
+                            ctx,
+                            header.has_desc,
+                            Type::parse,
+                            "type",
+                        )?,
+                        from: arg,
+                    },
+                    span: ctx.span(),
+                })),
+                ("enum", Some(arg), "Value", _) => Ok(Some(Table {
+                    name: header.path,
+                    kind: TableKind::ValueMap {
+                        rows: collect_rows(
+                            ctx,
+                            header.has_desc,
+                            Lit::parse,
+                            "literal",
+                        )?,
+                        from: arg,
+                    },
+                    span: ctx.span(),
+                })),
+                ("enum", Some(_), _, _) => Err(header
+                    .first_col
+                    .span()
+                    .error(ErrorKind::Expected("`Type` or `Value`".into()))),
+
+                _ => Err(header.kw.span().error(ErrorKind::Expected(
+                    "`message` or `enum`".to_string(),
+                ))),
+            }
+        })
+    }
+}
+

--- a/cerberus-tables/src/ast/parser.rs
+++ b/cerberus-tables/src/ast/parser.rs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::fmt;
+
 use crate::ast::*;
 
 /// Parse state for the table parser.
@@ -637,4 +639,3 @@ impl<'md> Table<'md> {
         })
     }
 }
-

--- a/cerberus-tables/src/main.rs
+++ b/cerberus-tables/src/main.rs
@@ -14,23 +14,23 @@ mod ast;
 
 #[derive(Debug, StructOpt)]
 struct Options {
-    /// The output format; one of raw-ast, tables, in-place, or rust.
+    /// One of raw-ast, tables, in-place, or rust.
     #[structopt(long, short)]
-    output: Output,
+    mode: Mode,
 
     /// A Markdown file to parse tables from.
     input: PathBuf,
 }
 
 #[derive(Debug)]
-enum Output {
+enum Mode {
     RawAst,
     Tables,
     InPlace,
     Rust,
 }
 
-impl FromStr for Output {
+impl FromStr for Mode {
     type Err = String;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
@@ -58,5 +58,18 @@ fn main() {
             println!("{:4}> {}", num, line);
         }
     }
-    println!("{:#?}", ast);
+
+    match opts.mode {
+        Mode::RawAst => {
+            for table in ast {
+                println!("{:#?}", table);
+            }
+        },
+        Mode::Tables => {
+            for table in ast {
+                println!("{}", table);
+            }
+        },
+        _ => unimplemented!(),
+    }
 }

--- a/cerberus-tables/src/main.rs
+++ b/cerberus-tables/src/main.rs
@@ -18,6 +18,11 @@ struct Options {
     #[structopt(long, short)]
     mode: Mode,
 
+    /// The maximum width, in characters, that table output
+    /// may have.
+    #[structopt(long, short = "w")]
+    max_width: Option<usize>,
+
     /// A Markdown file to parse tables from.
     input: PathBuf,
 }
@@ -70,15 +75,27 @@ fn main() {
         }
         Mode::Tables => {
             for table in ast {
-                println!("{}", table);
+                println!(
+                    "{}",
+                    ast::TableWithOptions {
+                        table: &table,
+                        max_width: opts.max_width,
+                    }
+                );
             }
         }
         Mode::TablesAndProse => {
             let mut prev = 0;
             for table in ast {
                 let (start, end) = table.span.byte_range();
-                let prose = &src.text[prev..start];
-                print!("{}{}", prose, table);
+                print!("{}", &src.text[prev..start]);
+                print!(
+                    "{}",
+                    ast::TableWithOptions {
+                        table: &table,
+                        max_width: opts.max_width,
+                    }
+                );
                 prev = end;
             }
             print!("{}", &src.text[prev..]);

--- a/cerberus-tables/src/main.rs
+++ b/cerberus-tables/src/main.rs
@@ -1,0 +1,62 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+//! A parser for Cerberus protocol tables.
+
+use std::fs;
+use std::path::PathBuf;
+use std::str::FromStr;
+
+use structopt::StructOpt;
+
+mod ast;
+
+#[derive(Debug, StructOpt)]
+struct Options {
+    /// The output format; one of raw-ast, tables, in-place, or rust.
+    #[structopt(long, short)]
+    output: Output,
+
+    /// A Markdown file to parse tables from.
+    input: PathBuf,
+}
+
+#[derive(Debug)]
+enum Output {
+    RawAst,
+    Tables,
+    InPlace,
+    Rust,
+}
+
+impl FromStr for Output {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "raw-ast" => Ok(Self::RawAst),
+            "tables" => Ok(Self::Tables),
+            "in-place" => Ok(Self::InPlace),
+            "rust" => Ok(Self::Rust),
+            _ => Err(format!("unknown format: {}", s)),
+        }
+    }
+}
+
+fn main() {
+    let opts = Options::from_args();
+    let text = fs::read_to_string(&opts.input).unwrap();
+    let src = ast::MarkdownFile {
+        file_name: opts.input,
+        text,
+    };
+
+    let (ast, errors) = src.parse_tables();
+    for error in errors {
+        println!("{:?}", error);
+        for (num, line) in error.span.lines() {
+            println!("{:4}> {}", num, line);
+        }
+    }
+    println!("{:#?}", ast);
+}


### PR DESCRIPTION
There is a [recently merged RFC](https://github.com/opencomputeproject/Security/blob/master/RoT/Protocol/RFCs/0003-Command_Definition_Syntax.md) in Cerberus that adds tables to the effect of

`message AttestationLogFormat`
| Type     | Name                | Description                                 |
|----------|---------------------|---------------------------------------------|
| `0x0b`   | `header_format`     | Header format version.                      |
| `b16`    | `entry_length`      | Total length of the entry.                  |
| `b32`    | `unique_id`         | A unique identifier for the entry.          |
| `b32`    | `tcg_type`          | The associated TCG event type.              |
| `b8`     | `measurement_index` | Index of the measurement within the PMR.    |
| `b8`     | `pmr_index`         | Index of the PMR being extended.            |
| `0x0000` | `_`                 | Reserved.                                   |
| `b8`     | `digest_count`      | Number of digests.                          |
| `0x0000` | `_`                 | Reserved.                                   |
| `0x0b`   | `digest_algo_id`    | Digest algorithm ID, fixed to SHA-256.      |
| `b256`   | `digest`            | SHA-256 digest used to extend the measurement. |
| `[b32]`  | `measurement`       | The measurement value.                      |

I designed these tables on the assertion I wanted them to be machine-parseable; this PR is intended to make well on that promise.

Currently, I can only parse things and pretty-print them. Testing this kind of parser is... a pain, so I'm open to suggestions for parsing strategies. I'm not sure if unit tests will be terrifically useful but I can definitely give them a shot.

A followup will add a mode for emitting naive `std`-using Rust code, and from there we can work on writing a real parser generator.